### PR TITLE
[codex] Fix EyeMag PDF truncation

### DIFF
--- a/interface/patient_file/report/007.php
+++ b/interface/patient_file/report/007.php
@@ -75,6 +75,59 @@ if (!function_exists('getMedicalProblems')) {
     }
 }
 
+if (!function_exists('buildEyeMagExamOutputForReport')) {
+    function buildEyeMagExamOutputForReport($form_encounter, $pid)
+    {
+        $encounter_data = getEyeMagEncounterData($form_encounter, $pid);
+        if (!$encounter_data) {
+            return '';
+        }
+
+        return ExamOftal($form_encounter,
+            $encounter_data['CC1'] ?? '',
+            $encounter_data['RBROW'] ?? '',
+            $encounter_data['LBROW'] ?? '',
+            $encounter_data['RUL'] ?? '',
+            $encounter_data['LUL'] ?? '',
+            $encounter_data['RLL'] ?? '',
+            $encounter_data['LLL'] ?? '',
+            $encounter_data['RMCT'] ?? '',
+            $encounter_data['LMCT'] ?? '',
+            $encounter_data['RADNEXA'] ?? '',
+            $encounter_data['LADNEXA'] ?? '',
+            $encounter_data['EXT_COMMENTS'] ?? '',
+            $encounter_data['SCODVA'] ?? '',
+            $encounter_data['SCOSVA'] ?? '',
+            $encounter_data['ODVA'] ?? '',
+            $encounter_data['OSVA'] ?? '',
+            $encounter_data['ODIOPAP'] ?? '',
+            $encounter_data['OSIOPAP'] ?? '',
+            $encounter_data['ODCONJ'] ?? '',
+            $encounter_data['OSCONJ'] ?? '',
+            $encounter_data['ODCORNEA'] ?? '',
+            $encounter_data['OSCORNEA'] ?? '',
+            $encounter_data['ODAC'] ?? '',
+            $encounter_data['OSAC'] ?? '',
+            $encounter_data['ODLENS'] ?? '',
+            $encounter_data['OSLENS'] ?? '',
+            $encounter_data['ODIRIS'] ?? '',
+            $encounter_data['OSIRIS'] ?? '',
+            $encounter_data['ODDISC'] ?? '',
+            $encounter_data['OSDISC'] ?? '',
+            $encounter_data['ODCUP'] ?? '',
+            $encounter_data['OSCUP'] ?? '',
+            $encounter_data['ODMACULA'] ?? '',
+            $encounter_data['OSMACULA'] ?? '',
+            $encounter_data['ODVESSELS'] ?? '',
+            $encounter_data['OSVESSELS'] ?? '',
+            $encounter_data['ODPERIPH'] ?? '',
+            $encounter_data['OSPERIPH'] ?? '',
+            $encounter_data['ODVITREOUS'] ?? '',
+            $encounter_data['OSVITREOUS'] ?? ''
+        );
+    }
+}
+
 
 // Limpiar (descartar) cualquier salida previa
 //ob_end_clean();
@@ -333,16 +386,10 @@ renderPatientInfoTable($titleres, $encounter);
         <td colspan="2" class="blanco_left">
             <?php
             if ($formdir === 'eye_mag') {
-                $encounter_data = getEyeMagEncounterData($form_encounter, $pid);
-                if ($encounter_data) {
-                    extract($encounter_data);
-                    $examOutput = ExamOftal($val, $CC1 ?? '', $RBROW ?? '', $LBROW ?? '', $RUL ?? '', $LUL ?? '', $RLL ?? '', $LLL ?? '', $RMCT ?? '', $LMCT ?? '', $RADNEXA ?? '', $LADNEXA ?? '', $EXT_COMMENTS ?? '',
-                        $SCODVA ?? '', $SCOSVA ?? '', $ODVA ?? '', $OSVA ?? '', $ODIOPAP ?? '', $OSIOPAP ?? '', $ODCONJ ?? '', $OSCONJ ?? '', $ODCORNEA ?? '', $OSCORNEA ?? '', $ODAC ?? '', $OSAC ?? '', $ODLENS ?? '', $OSLENS ?? '', $ODIRIS ?? '', $OSIRIS ?? '',
-                        $ODDISC ?? '', $OSDISC ?? '', $ODCUP ?? '', $OSCUP ?? '', $ODMACULA ?? '', $OSMACULA ?? '', $ODVESSELS ?? '', $OSVESSELS ?? '', $ODPERIPH ?? '', $OSPERIPH ?? '', $ODVITREOUS ?? '', $OSVITREOUS ?? '');
-                    if (!empty($examOutput)) {
-                        $enfermedadActual = generateEnfermedadProblemaActual($reason, $examOutput);
-                        echo wordwrap($enfermedadActual, 165, "</td></tr><tr><td colspan='2' class='blanco_left'>", true);
-                    }
+                $examOutput = buildEyeMagExamOutputForReport($form_encounter, $pid);
+                if (!empty($examOutput)) {
+                    $enfermedadActual = generateEnfermedadProblemaActual($reason, $examOutput);
+                    echo wordwrap($enfermedadActual, 165, "</td></tr><tr><td colspan='2' class='blanco_left'>", true);
                 }
             }
             ?>
@@ -543,15 +590,9 @@ renderPatientInfoTable($titleres, $encounter);
             <td colspan="15" class="blanco_left">
                 <?php
                 if ($formdir === 'eye_mag') {
-                    $encounter_data = getEyeMagEncounterData($form_encounter, $pid);
-                    if ($encounter_data) {
-                        extract($encounter_data);
-                        $examOutput = ExamOftal($val, $CC1 ?? '', $RBROW ?? '', $LBROW ?? '', $RUL ?? '', $LUL ?? '', $RLL ?? '', $LLL ?? '', $RMCT ?? '', $LMCT ?? '', $RADNEXA ?? '', $LADNEXA ?? '', $EXT_COMMENTS ?? '',
-                            $SCODVA ?? '', $SCOSVA ?? '', $ODVA ?? '', $OSVA ?? '', $ODIOPAP ?? '', $OSIOPAP ?? '', $ODCONJ ?? '', $OSCONJ ?? '', $ODCORNEA ?? '', $OSCORNEA ?? '', $ODAC ?? '', $OSAC ?? '', $ODLENS ?? '', $OSLENS ?? '', $ODIRIS ?? '', $OSIRIS ?? '',
-                            $ODDISC ?? '', $OSDISC ?? '', $ODCUP ?? '', $OSCUP ?? '', $ODMACULA ?? '', $OSMACULA ?? '', $ODVESSELS ?? '', $OSVESSELS ?? '', $ODPERIPH ?? '', $OSPERIPH ?? '', $ODVITREOUS ?? '', $OSVITREOUS ?? '');
-                        if (!empty($examOutput)) {
-                            echo wordwrap($examOutput, 165, "</td></tr><tr><td colspan='15' class='blanco_left'>", true);
-                        }
+                    $examOutput = buildEyeMagExamOutputForReport($form_encounter, $pid);
+                    if (!empty($examOutput)) {
+                        echo wordwrap($examOutput, 165, "</td></tr><tr><td colspan='15' class='blanco_left'>", true);
                     }
                 }
                 ?>
@@ -737,15 +778,9 @@ renderPatientInfoTable($titleres, $encounter);
                 <td class="blanco_left">
                     <?php
                     if ($formdir === 'eye_mag') {
-                        $encounter_data = getEyeMagEncounterData($form_encounter, $pid);
-                        if ($encounter_data) {
-                            extract($encounter_data);
-                            $examOutput = ExamOftal($val, $CC1 ?? '', $RBROW ?? '', $LBROW ?? '', $RUL ?? '', $LUL ?? '', $RLL ?? '', $LLL ?? '', $RMCT ?? '', $LMCT ?? '', $RADNEXA ?? '', $LADNEXA ?? '', $EXT_COMMENTS ?? '',
-                                $SCODVA ?? '', $SCOSVA ?? '', $ODVA ?? '', $OSVA ?? '', $ODIOPAP ?? '', $OSIOPAP ?? '', $ODCONJ ?? '', $OSCONJ ?? '', $ODCORNEA ?? '', $OSCORNEA ?? '', $ODAC ?? '', $OSAC ?? '', $ODLENS ?? '', $OSLENS ?? '', $ODIRIS ?? '', $OSIRIS ?? '',
-                                $ODDISC ?? '', $OSDISC ?? '', $ODCUP ?? '', $OSCUP ?? '', $ODMACULA ?? '', $OSMACULA ?? '', $ODVESSELS ?? '', $OSVESSELS ?? '', $ODPERIPH ?? '', $OSPERIPH ?? '', $ODVITREOUS ?? '', $OSVITREOUS ?? '');
-                            if (!empty($examOutput)) {
-                                echo wordwrap($examOutput, 165, "</td></tr><tr><td class='blanco_left'>", true);
-                            }
+                        $examOutput = buildEyeMagExamOutputForReport($form_encounter, $pid);
+                        if (!empty($examOutput)) {
+                            echo wordwrap($examOutput, 165, "</td></tr><tr><td class='blanco_left'>", true);
                         }
                     }
                     ?>
@@ -1033,15 +1068,9 @@ renderPatientInfoTable($titleres, $encounter);
                         <td class="blanco_left">
                             <?php
                             if ($formdir === 'eye_mag') {
-                                $encounter_data = getEyeMagEncounterData($form_encounter, $pid);
-                                if ($encounter_data) {
-                                    extract($encounter_data);
-                                    $examOutput = ExamOftal($val, $CC1 ?? '', $RBROW ?? '', $LBROW ?? '', $RUL ?? '', $LUL ?? '', $RLL ?? '', $LLL ?? '', $RMCT ?? '', $LMCT ?? '', $RADNEXA ?? '', $LADNEXA ?? '', $EXT_COMMENTS ?? '',
-                                        $SCODVA ?? '', $SCOSVA ?? '', $ODVA ?? '', $OSVA ?? '', $ODIOPAP ?? '', $OSIOPAP ?? '', $ODCONJ ?? '', $OSCONJ ?? '', $ODCORNEA ?? '', $OSCORNEA ?? '', $ODAC ?? '', $OSAC ?? '', $ODLENS ?? '', $OSLENS ?? '', $ODIRIS ?? '', $OSIRIS ?? '',
-                                        $ODDISC ?? '', $OSDISC ?? '', $ODCUP ?? '', $OSCUP ?? '', $ODMACULA ?? '', $OSMACULA ?? '', $ODVESSELS ?? '', $OSVESSELS ?? '', $ODPERIPH ?? '', $OSPERIPH ?? '', $ODVITREOUS ?? '', $OSVITREOUS ?? '');
-                                    if (!empty($examOutput)) {
-                                        echo wordwrap($examOutput, 165, "</td></tr><tr><td class='blanco_left'>", true);
-                                    }
+                                $examOutput = buildEyeMagExamOutputForReport($form_encounter, $pid);
+                                if (!empty($examOutput)) {
+                                    echo wordwrap($examOutput, 165, "</td></tr><tr><td class='blanco_left'>", true);
                                 }
                             }
                             ?>

--- a/interface/patient_file/report/debug_eyemag_cli.php
+++ b/interface/patient_file/report/debug_eyemag_cli.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * CLI-only EyeMag diagnostic for contrareferencia output.
+ *
+ * Usage:
+ *   php debug_eyemag_cli.php 21506 94927 44738
+ */
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit;
+}
+
+$ignoreAuth = true;
+$_GET['site'] = $_GET['site'] ?? 'default';
+$_SERVER['HTTP_HOST'] = $_SERVER['HTTP_HOST'] ?? 'default';
+
+chdir(__DIR__);
+
+require_once("../../globals.php");
+require_once($GLOBALS['srcdir'] . "/iess.inc.php");
+
+$pid = isset($argv[1]) ? (int)$argv[1] : 0;
+$encounter = isset($argv[2]) ? (int)$argv[2] : 0;
+$formId = isset($argv[3]) ? (int)$argv[3] : 0;
+
+if (!$pid || !$encounter || !$formId) {
+    fwrite(STDERR, "Usage: php debug_eyemag_cli.php <pid> <encounter> <form_id>\n");
+    exit(1);
+}
+
+$row = sqlQuery(
+    "SELECT
+        f.id AS forms_id,
+        f.pid,
+        f.encounter,
+        f.form_id,
+        f.form_name,
+        h.CC1,
+        a.SCODVA,
+        a.SCOSVA,
+        v.ODIOPAP,
+        v.OSIOPAP,
+        e.RBROW,
+        e.LBROW,
+        e.RUL,
+        e.LUL,
+        e.RLL,
+        e.LLL,
+        e.RMCT,
+        e.LMCT,
+        e.RADNEXA,
+        e.LADNEXA,
+        e.EXT_COMMENTS,
+        ant.ODCONJ,
+        ant.OSCONJ,
+        ant.ODCORNEA,
+        ant.OSCORNEA,
+        ant.ODAC,
+        ant.OSAC,
+        ant.ODLENS,
+        ant.OSLENS,
+        ant.ODIRIS,
+        ant.OSIRIS,
+        post.ODDISC,
+        post.OSDISC,
+        post.ODCUP,
+        post.OSCUP,
+        post.ODMACULA,
+        post.OSMACULA,
+        post.ODVESSELS,
+        post.OSVESSELS,
+        post.ODPERIPH,
+        post.OSPERIPH,
+        post.ODVITREOUS,
+        post.OSVITREOUS
+     FROM forms f
+     LEFT JOIN form_eye_hpi h ON f.form_id = h.id
+     LEFT JOIN form_eye_acuity a ON f.form_id = a.id
+     LEFT JOIN form_eye_vitals v ON f.form_id = v.id
+     LEFT JOIN form_eye_external e ON f.form_id = e.id
+     LEFT JOIN form_eye_antseg ant ON f.form_id = ant.id
+     LEFT JOIN form_eye_postseg post ON f.form_id = post.id
+     WHERE f.pid = ?
+       AND f.encounter = ?
+       AND f.formdir = 'eye_mag'
+       AND f.form_id = ?
+       AND f.deleted != 1",
+    array($pid, $encounter, $formId)
+);
+
+function debugEyePrintFields($title, $row)
+{
+    echo "\n=== $title ===\n";
+    if (!$row) {
+        echo "No rows\n";
+        return;
+    }
+
+    foreach ($row as $key => $value) {
+        if ($value !== null && $value !== '') {
+            echo $key . ": " . strip_tags((string)$value) . "\n";
+        }
+    }
+}
+
+function debugEyeExamOutput($row, $encounter)
+{
+    if (!$row) {
+        return '';
+    }
+
+    return strip_tags(ExamOftal(
+        $encounter,
+        $row['CC1'] ?? '',
+        $row['RBROW'] ?? '',
+        $row['LBROW'] ?? '',
+        $row['RUL'] ?? '',
+        $row['LUL'] ?? '',
+        $row['RLL'] ?? '',
+        $row['LLL'] ?? '',
+        $row['RMCT'] ?? '',
+        $row['LMCT'] ?? '',
+        $row['RADNEXA'] ?? '',
+        $row['LADNEXA'] ?? '',
+        $row['EXT_COMMENTS'] ?? '',
+        $row['SCODVA'] ?? '',
+        $row['SCOSVA'] ?? '',
+        '',
+        '',
+        $row['ODIOPAP'] ?? '',
+        $row['OSIOPAP'] ?? '',
+        $row['ODCONJ'] ?? '',
+        $row['OSCONJ'] ?? '',
+        $row['ODCORNEA'] ?? '',
+        $row['OSCORNEA'] ?? '',
+        $row['ODAC'] ?? '',
+        $row['OSAC'] ?? '',
+        $row['ODLENS'] ?? '',
+        $row['OSLENS'] ?? '',
+        $row['ODIRIS'] ?? '',
+        $row['OSIRIS'] ?? '',
+        $row['ODDISC'] ?? '',
+        $row['OSDISC'] ?? '',
+        $row['ODCUP'] ?? '',
+        $row['OSCUP'] ?? '',
+        $row['ODMACULA'] ?? '',
+        $row['OSMACULA'] ?? '',
+        $row['ODVESSELS'] ?? '',
+        $row['OSVESSELS'] ?? '',
+        $row['ODPERIPH'] ?? '',
+        $row['OSPERIPH'] ?? '',
+        $row['ODVITREOUS'] ?? '',
+        $row['OSVITREOUS'] ?? ''
+    ));
+}
+
+function debugEyeValue($row, $key)
+{
+    return isset($row[$key]) ? trim((string)$row[$key]) : '';
+}
+
+function debugEyePrintCondition($label, $condition)
+{
+    echo $label . ': ' . ($condition ? 'YES' : 'NO') . "\n";
+}
+
+function debugEyePrintSections($row)
+{
+    echo "\n=== Section checks ===\n";
+    if (!$row) {
+        echo "No rows\n";
+        return;
+    }
+
+    $hasExternal = debugEyeValue($row, 'RBROW') || debugEyeValue($row, 'LBROW') || debugEyeValue($row, 'RUL') || debugEyeValue($row, 'LUL') || debugEyeValue($row, 'RLL') || debugEyeValue($row, 'LLL') || debugEyeValue($row, 'RMCT') || debugEyeValue($row, 'LMCT') || debugEyeValue($row, 'RADNEXA') || debugEyeValue($row, 'LADNEXA') || debugEyeValue($row, 'EXT_COMMENTS');
+    $hasAntSeg = debugEyeValue($row, 'ODCONJ') || debugEyeValue($row, 'ODCORNEA') || debugEyeValue($row, 'ODAC') || debugEyeValue($row, 'ODLENS') || debugEyeValue($row, 'ODIRIS') || debugEyeValue($row, 'OSCONJ') || debugEyeValue($row, 'OSCORNEA') || debugEyeValue($row, 'OSAC') || debugEyeValue($row, 'OSLENS') || debugEyeValue($row, 'OSIRIS');
+    $hasPostSeg = debugEyeValue($row, 'ODDISC') || debugEyeValue($row, 'OSDISC') || debugEyeValue($row, 'ODCUP') || debugEyeValue($row, 'OSCUP') || debugEyeValue($row, 'ODMACULA') || debugEyeValue($row, 'OSMACULA') || debugEyeValue($row, 'ODVESSELS') || debugEyeValue($row, 'OSVESSELS') || debugEyeValue($row, 'ODPERIPH') || debugEyeValue($row, 'OSPERIPH') || debugEyeValue($row, 'ODVITREOUS') || debugEyeValue($row, 'OSVITREOUS');
+
+    debugEyePrintCondition('Has external data', $hasExternal);
+    debugEyePrintCondition('Has anterior segment data', $hasAntSeg);
+    debugEyePrintCondition('Has posterior segment data', $hasPostSeg);
+}
+
+function debugEyePrintRawValue($row, $key)
+{
+    $value = isset($row[$key]) ? (string)$row[$key] : '';
+    echo $key . " raw json: " . json_encode($value, JSON_UNESCAPED_UNICODE) . "\n";
+    echo $key . " hex: " . bin2hex($value) . "\n";
+}
+
+function debugEyePrintRawSuspiciousFields($row)
+{
+    echo "\n=== Raw suspicious fields ===\n";
+    if (!$row) {
+        echo "No rows\n";
+        return;
+    }
+
+    foreach (array('CC1', 'SCODVA', 'SCOSVA', 'ODVA', 'OSVA') as $key) {
+        debugEyePrintRawValue($row, $key);
+    }
+
+    echo "\nFields containing angle brackets:\n";
+    $found = false;
+    foreach ($row as $key => $value) {
+        $value = (string)$value;
+        if (strpos($value, '<') !== false || strpos($value, '>') !== false) {
+            $found = true;
+            echo $key . ": " . json_encode($value, JSON_UNESCAPED_UNICODE) . "\n";
+        }
+    }
+    if (!$found) {
+        echo "None\n";
+    }
+}
+
+debugEyePrintFields('DB fields for selected eye_mag form', $row);
+debugEyePrintSections($row);
+debugEyePrintRawSuspiciousFields($row);
+
+echo "\n=== ExamOftal output for selected eye_mag form ===\n";
+echo debugEyeExamOutput($row, $encounter) . "\n";
+
+$legacyRow = getEyeMagEncounterData($encounter, $pid);
+debugEyePrintFields('Legacy getEyeMagEncounterData fields', $legacyRow);
+debugEyePrintSections($legacyRow);
+debugEyePrintRawSuspiciousFields($legacyRow);
+
+echo "\n=== ExamOftal output from legacy getEyeMagEncounterData ===\n";
+echo debugEyeExamOutput($legacyRow, $encounter) . "\n";

--- a/library/iess.inc.php
+++ b/library/iess.inc.php
@@ -1053,6 +1053,9 @@ function ExamOftal($form_encounter, $CC1, $RBROW, $LBROW, $RUL, $LUL, $RLL, $LLL
 {
     $dateform = getEncounterDateByEncounter($form_encounter);
     $ExamOFT = "<b>" . "(" . text(oeFormatSDFT(strtotime($dateform["date"]))) . ") " . "</b>";
+    $formatEyeValue = function ($value) {
+        return text(strtolower((string)$value));
+    };
 
     $fields = [$CC1, $RBROW, $LBROW, $RUL, $LUL, $RLL, $LLL, $RMCT, $LMCT, $RADNEXA, $LADNEXA, $EXT_COMMENTS, $SCODVA, $SCOSVA, $ODVA, $OSVA, $ODIOPAP, $OSIOPAP, $OSCONJ, $ODCONJ, $ODCORNEA, $OSCORNEA, $ODAC, $OSAC, $ODLENS, $OSLENS, $ODIRIS, $OSIRIS, $ODDISC, $OSDISC, $ODCUP, $OSCUP, $ODMACULA, $OSMACULA, $ODVESSELS, $OSVESSELS, $ODPERIPH, $OSPERIPH, $ODVITREOUS, $OSVITREOUS];
 
@@ -1060,46 +1063,46 @@ function ExamOftal($form_encounter, $CC1, $RBROW, $LBROW, $RUL, $LUL, $RLL, $LLL
 
     if (array_filter($fields)) {
         if ($CC1) {
-            $ExamOFT .= strtolower($CC1) . ", ";
+            $ExamOFT .= $formatEyeValue($CC1) . ", ";
         }
         if ($SCODVA || $SCOSVA) {
             $ExamOFT .= "Agudeza Visual sin Corrección: ";
             if ($SCODVA) {
-                $ExamOFT .= "Ojo Derecho: " . strtolower($SCODVA) . ", ";
+                $ExamOFT .= "Ojo Derecho: " . $formatEyeValue($SCODVA) . ", ";
             }
             if ($SCOSVA) {
-                $ExamOFT .= "Ojo Izquierdo: " . strtolower($SCOSVA) . ", ";
+                $ExamOFT .= "Ojo Izquierdo: " . $formatEyeValue($SCOSVA) . ", ";
             }
         }
         if ($ODVA || $OSVA) {
             $ExamOFT .= "Agudeza Visual con Corrección: ";
             if ($ODVA) {
-                $ExamOFT .= "Ojo Derecho: " . strtolower($ODVA) . ", ";
+                $ExamOFT .= "Ojo Derecho: " . $formatEyeValue($ODVA) . ", ";
             }
             if ($OSVA) {
-                $ExamOFT .= "Ojo Izquierdo: " . strtolower($OSVA) . ", ";
+                $ExamOFT .= "Ojo Izquierdo: " . $formatEyeValue($OSVA) . ", ";
             }
         }
 
         if ($ODIOPAP || $OSIOPAP) {
             $ExamOFT .= "Presión Intraocular: ";
             if ($ODIOPAP) {
-                $ExamOFT .= "Ojo Derecho: " . strtolower($ODIOPAP) . ", ";
+                $ExamOFT .= "Ojo Derecho: " . $formatEyeValue($ODIOPAP) . ", ";
             }
             if ($OSIOPAP) {
-                $ExamOFT .= "Ojo Izquierdo: " . strtolower($OSIOPAP) . ", ";
+                $ExamOFT .= "Ojo Izquierdo: " . $formatEyeValue($OSIOPAP) . ", ";
             }
         }
 
         if ($RBROW || $LBROW || $RUL || $LUL || $RLL || $LLL || $RMCT || $LMCT || $RADNEXA || $LADNEXA || $EXT_COMMENTS) {
             $ExamOFT .= "Examen Externo: ";
             if ($RBROW || $RUL || $RLL || $RMCT || $RADNEXA) {
-                $ExamOFT .= "Ojo Derecho: " . strtolower($RBROW) . " " . strtolower($RUL) . " " . strtolower($RLL) . " " . strtolower($RMCT) . " " . strtolower($RADNEXA) . " ";
+                $ExamOFT .= "Ojo Derecho: " . $formatEyeValue($RBROW) . " " . $formatEyeValue($RUL) . " " . $formatEyeValue($RLL) . " " . $formatEyeValue($RMCT) . " " . $formatEyeValue($RADNEXA) . " ";
             }
             if ($LBROW || $LUL || $LLL || $LMCT || $LADNEXA) {
-                $ExamOFT .= "Ojo Izquierdo: " . strtolower($LBROW) . " " . strtolower($LUL) . " " . strtolower($LLL) . " " . strtolower($LMCT) . " " . strtolower($LADNEXA) . " ";
+                $ExamOFT .= "Ojo Izquierdo: " . $formatEyeValue($LBROW) . " " . $formatEyeValue($LUL) . " " . $formatEyeValue($LLL) . " " . $formatEyeValue($LMCT) . " " . $formatEyeValue($LADNEXA) . " ";
             }
-            $ExamOFT .= strtolower($EXT_COMMENTS);
+            $ExamOFT .= $formatEyeValue($EXT_COMMENTS);
         }
         if ($ODCONJ || $ODCORNEA || $ODAC || $ODLENS || $ODIRIS || $OSCONJ || $OSCORNEA || $OSAC || $OSLENS || $OSIRIS) {
             $ExamOFT .= "Biomicroscopía: ";
@@ -1107,37 +1110,37 @@ function ExamOftal($form_encounter, $CC1, $RBROW, $LBROW, $RUL, $LUL, $RLL, $LLL
                 $ExamOFT .= "Ojo Derecho: ";
             }
             if ($ODCONJ) {
-                $ExamOFT .= "Conjuntiva " . strtolower($ODCONJ) . ", ";
+                $ExamOFT .= "Conjuntiva " . $formatEyeValue($ODCONJ) . ", ";
             }
             if ($ODCORNEA) {
-                $ExamOFT .= "Córnea " . strtolower($ODCORNEA) . ", ";
+                $ExamOFT .= "Córnea " . $formatEyeValue($ODCORNEA) . ", ";
             }
             if ($ODAC) {
-                $ExamOFT .= "Cámara Anterior " . strtolower($ODAC) . ", ";
+                $ExamOFT .= "Cámara Anterior " . $formatEyeValue($ODAC) . ", ";
             }
             if ($ODLENS) {
-                $ExamOFT .= "Cristalino " . strtolower($ODLENS) . ", ";
+                $ExamOFT .= "Cristalino " . $formatEyeValue($ODLENS) . ", ";
             }
             if ($ODIRIS) {
-                $ExamOFT .= "Iris " . strtolower($ODIRIS) . ", ";
+                $ExamOFT .= "Iris " . $formatEyeValue($ODIRIS) . ", ";
             }
             if ($OSCONJ || $OSCORNEA || $OSAC || $OSLENS || $OSIRIS) {
                 $ExamOFT .= "Ojo Izquierdo: ";
             }
             if ($OSCONJ) {
-                $ExamOFT .= "Conjuntiva " . strtolower($OSCONJ) . ", ";
+                $ExamOFT .= "Conjuntiva " . $formatEyeValue($OSCONJ) . ", ";
             }
             if ($OSCORNEA) {
-                $ExamOFT .= "Córnea " . strtolower($OSCORNEA) . ", ";
+                $ExamOFT .= "Córnea " . $formatEyeValue($OSCORNEA) . ", ";
             }
             if ($OSAC) {
-                $ExamOFT .= "Cámara Anterior " . strtolower($OSAC) . ", ";
+                $ExamOFT .= "Cámara Anterior " . $formatEyeValue($OSAC) . ", ";
             }
             if ($OSLENS) {
-                $ExamOFT .= "Cristalino " . strtolower($OSLENS) . ", ";
+                $ExamOFT .= "Cristalino " . $formatEyeValue($OSLENS) . ", ";
             }
             if ($OSIRIS) {
-                $ExamOFT .= "Iris " . strtolower($OSIRIS) . ", ";
+                $ExamOFT .= "Iris " . $formatEyeValue($OSIRIS) . ", ";
             }
         }
         if ($ODDISC || $OSDISC || $ODCUP || $OSCUP || $ODMACULA || $OSMACULA || $ODVESSELS || $OSVESSELS || $ODPERIPH || $OSPERIPH || $ODVITREOUS || $OSVITREOUS) {
@@ -1148,44 +1151,44 @@ function ExamOftal($form_encounter, $CC1, $RBROW, $LBROW, $RUL, $LUL, $RLL, $LLL
             $ExamOFT .= "Ojo Derecho: ";
         }
         if ($ODDISC) {
-            $ExamOFT .= "Disco " . strtolower($ODDISC) . ", ";
+            $ExamOFT .= "Disco " . $formatEyeValue($ODDISC) . ", ";
         }
         if ($ODCUP) {
-            $ExamOFT .= "Copa " . strtolower($ODCUP) . ", ";
+            $ExamOFT .= "Copa " . $formatEyeValue($ODCUP) . ", ";
         }
         if ($ODMACULA) {
-            $ExamOFT .= "Mácula " . strtolower($ODMACULA) . ", ";
+            $ExamOFT .= "Mácula " . $formatEyeValue($ODMACULA) . ", ";
         }
         if ($ODVESSELS) {
-            $ExamOFT .= "Vasos " . strtolower($ODVESSELS) . ", ";
+            $ExamOFT .= "Vasos " . $formatEyeValue($ODVESSELS) . ", ";
         }
         if ($ODPERIPH) {
-            $ExamOFT .= "Periferia " . strtolower($ODPERIPH) . ", ";
+            $ExamOFT .= "Periferia " . $formatEyeValue($ODPERIPH) . ", ";
         }
         if ($ODVITREOUS) {
-            $ExamOFT .= "Vítreo " . strtolower($ODVITREOUS) . ", ";
+            $ExamOFT .= "Vítreo " . $formatEyeValue($ODVITREOUS) . ", ";
         }
         //Retina Ojo Izquierdo
         if ($OSDISC || $OSCUP || $OSMACULA || $OSVESSELS || $OSPERIPH || $OSVITREOUS) {
             $ExamOFT .= "Ojo Izquierdo: ";
         }
         if ($OSDISC) {
-            $ExamOFT .= "Disco " . strtolower($OSDISC) . ", ";
+            $ExamOFT .= "Disco " . $formatEyeValue($OSDISC) . ", ";
         }
         if ($OSCUP) {
-            $ExamOFT .= "Copa " . strtolower($OSCUP) . ", ";
+            $ExamOFT .= "Copa " . $formatEyeValue($OSCUP) . ", ";
         }
         if ($OSMACULA) {
-            $ExamOFT .= "Mácula " . strtolower($OSMACULA) . ", ";
+            $ExamOFT .= "Mácula " . $formatEyeValue($OSMACULA) . ", ";
         }
         if ($OSVESSELS) {
-            $ExamOFT .= "Vasos " . strtolower($OSVESSELS) . ", ";
+            $ExamOFT .= "Vasos " . $formatEyeValue($OSVESSELS) . ", ";
         }
         if ($OSPERIPH) {
-            $ExamOFT .= "Periferia " . strtolower($OSPERIPH) . ", ";
+            $ExamOFT .= "Periferia " . $formatEyeValue($OSPERIPH) . ", ";
         }
         if ($OSVITREOUS) {
-            $ExamOFT .= "Vítreo " . strtolower($OSVITREOUS) . ", ";
+            $ExamOFT .= "Vítreo " . $formatEyeValue($OSVITREOUS) . ", ";
         }
         return $ExamOFT;
     }


### PR DESCRIPTION
## Summary
- Escape EyeMag clinical values before inserting them into PDF HTML output.
- Centralize EyeMag exam rendering in the report template to avoid repeated extract-based calls.
- Add a CLI diagnostic script for reproducing EyeMag output issues by pid, encounter, and form id.

## Root cause
EyeMag values can contain angle brackets such as `100-1 <J 400`. The PDF HTML renderer interpreted the `<J 400` fragment as markup, so later sections like external exam, biomicroscopy, and posterior segment disappeared from the generated PDF.

## Validation
- `php -l library/iess.inc.php`
- `php -l interface/patient_file/report/007.php`
- `php -l interface/patient_file/report/debug_eyemag_cli.php`
- `git diff --check`