### PR TITLE
docs: add Patient V1 phase 1.3 readiness

### DIFF
--- a/docs/openemr-medforge-migration/README.md
+++ b/docs/openemr-medforge-migration/README.md
@@ -23,6 +23,8 @@ Este directorio versiona el contrato consolidado del programa de migracion Alta 
 
 `patient-v1` permanece **Draft**. La aprobacion actual es "revision con cambios", no autorizacion de implementacion ni piloto. No puede pasar a `Accepted` hasta completar los criterios del contrato consolidado.
 
+PR canonico activo: `#57` hacia `master`. PR `#56` queda superseded por `#57` porque `#57` contiene todo el contenido de `#56` mas las actualizaciones posteriores.
+
 1. Correccion P0 o aprobacion formal de la unicidad polimorfica de `core_external_aliases`.
 2. Preparacion formal de organizacion e instancias Alta Vision en Control Center.
 3. Fixtures sinteticos del piloto.
@@ -45,7 +47,9 @@ No se aceptan fixtures con datos reales ni muestras con PII.
 - No ejecutar migracion masiva desde este programa sin aprobacion de Jorge.
 - No modificar datos reales desde tareas de auditoria.
 - Toda decision clinica, cambio funcional o tratamiento de datos reales debe escalarse a Jorge.
-- `hc_number`, `pid`, `pubpid` y `form_id` son aliases externos o llaves legacy; no son identidad soberana de MedForge.
+- `patient_data.pid` de OpenEMR es alias tecnico obligatorio y deterministico; no es identidad soberana de MedForge.
+- `patient_data.pubpid` de OpenEMR equivale funcionalmente a `patient_data.hc_number` de MedForge: ambos representan cedula o numero de identificacion.
+- `form_id` es llave legacy de formulario/episodio, no identidad primaria de paciente.
 
 ## Artefactos vigentes
 

--- a/docs/openemr-medforge-migration/README.md
+++ b/docs/openemr-medforge-migration/README.md
@@ -11,27 +11,28 @@ Este directorio versiona el contrato consolidado del programa de migracion Alta 
 
 ## Fuentes verificadas
 
-- OpenEMR/AltaVision repo: `/Users/jorgeluisdevera/PhpstormProjects/altavision52`, base `master=16d2ee8939058b87ac49985c34648ace515362e2`; rama documental `codex/altavision-patient-v1-contract`.
+- OpenEMR/AltaVision repo: `/Users/jorgeluisdevera/PhpstormProjects/altavision52`, base `master=16d2ee8939058b87ac49985c34648ace515362e2`; rama documental limpia `codex/altavision-patient-v1-contract-clean`; rama Fase 1.3 `codex/altavision-phase-1-3-patient-readiness`.
 - Commit documental inicial: `e7b52bd42c00197be5762e11a59c6cd305f1512c`.
-- PR documental: `https://github.com/jl1dvg/altavision52/pull/55`.
+- PR documental limpio: `https://github.com/jl1dvg/altavision52/pull/56`. PR `#55` queda supersedido por contener commits no relacionados.
 - MedForge repo: `/Users/jorgeluisdevera/PhpstormProjects/MedForge`, `origin/staging=08f85d29c9f011d3c139ab56e3a6f0082c7a6d4d`.
 - Notion Knowledge OS: Protocolo Codex / Claude Code y Operational Core - Inventario Maestro.
-- Base de datos viva OpenEMR: acceso autorizado por Jorge, pero no disponible localmente; `sites/default/sqlconf.php` existe y es el origen de credenciales de OpenEMR, pero la conexion fallo con `DB_ERROR_CODE=2002`. `requires verification`.
+- Base de datos viva OpenEMR: verificada por SSH en VPS Alta Vision con acceso agregado/read-only, sin PII y sin escrituras. Evidencia en `readiness/phase-1-3-patient-readiness.md`.
 - Revision Claude Code MedForge: PR `https://github.com/jl1dvg/MedForge/pull/1065`, recomendacion `APPROVE WITH CHANGES`.
 
 ## Estado del contrato
 
 `patient-v1` permanece **Draft**. La aprobacion actual es "revision con cambios", no autorizacion de implementacion ni piloto. No puede pasar a `Accepted` hasta completar los criterios del contrato consolidado.
 
-1. Dump estructural sin datos de la base Alta Vision OpenEMR.
-2. Acceso read-only a la base real.
-3. Salida agregada de los comandos SQL read-only documentados en `contracts/patient-v1.md`.
+1. Correccion P0 o aprobacion formal de la unicidad polimorfica de `core_external_aliases`.
+2. Preparacion formal de organizacion e instancias Alta Vision en Control Center.
+3. Fixtures sinteticos del piloto.
+4. Revision final de Jorge.
 
 No se aceptan fixtures con datos reales ni muestras con PII.
 
 ## Roadmap de ejecucion
 
-1. Dominio Pacientes: cerrar contrato `patient-v1`, identidad clinica MedForge y piloto 20 pacientes anonimizados. Estado: Draft bloqueado por verificacion DB y deuda de unicidad de `core_external_aliases`.
+1. Dominio Pacientes: cerrar contrato `patient-v1`, identidad clinica MedForge y piloto 20 pacientes anonimizados. Estado: Draft; verificacion estructural OpenEMR parcialmente cumplida, bloqueado por deuda P0 de unicidad de `core_external_aliases`, Control Center y fixtures sinteticos.
 2. Dominio Encuentros/Consultas: mapear `forms.form_id`, `form_eye_base`, `consulta_data` y `core_episode_id`.
 3. Dominio Procedimientos proyectados: mapear `procedimiento_proyectado`, sedes, provider y estados legacy.
 4. Dominio Protocolos/Cirugias: mapear `protocolo_data`, formularios quirurgicos, insumos, diagnosticos y firmantes.
@@ -50,3 +51,5 @@ No se aceptan fixtures con datos reales ni muestras con PII.
 
 - `contracts/patient-v1.md`: contrato humano consolidado, fuente unica de estado, decisiones, mapping, riesgos, rollback, piloto y handoff.
 - `contracts/patient-v1.schema.json`: contrato tecnico JSON Schema para payloads.
+- `readiness/phase-1-3-patient-readiness.md`: informe de readiness Fase 1.3 con auditoria estructural/agregada real de OpenEMR.
+- `handoffs/medforge-core-alias-uniqueness-p0.md`: especificacion autocontenida para el PR P0 independiente de MedForge Core.

--- a/docs/openemr-medforge-migration/README.md
+++ b/docs/openemr-medforge-migration/README.md
@@ -1,0 +1,52 @@
+# Alta Vision - Migracion OpenEMR a MedForge
+
+Estado: `patient-v1` Draft, sin implementacion, sin piloto y sin migracion masiva.
+Owner humano para decisiones clinicas y datos reales: Jorge Luis De Vera.
+Agente responsable OpenEMR/AltaVision: Codex.
+Agente responsable implementaciones MedForge: Claude Code.
+
+## Alcance
+
+Este directorio versiona el contrato consolidado del programa de migracion Alta Vision - OpenEMR a MedForge. La fuente de codigo activa para MedForge es `origin/staging`; la fuente local de OpenEMR/AltaVision es este repositorio `altavision52`.
+
+## Fuentes verificadas
+
+- OpenEMR/AltaVision repo: `/Users/jorgeluisdevera/PhpstormProjects/altavision52`, base `master=16d2ee8939058b87ac49985c34648ace515362e2`; rama documental `codex/altavision-patient-v1-contract`.
+- Commit documental inicial: `e7b52bd42c00197be5762e11a59c6cd305f1512c`.
+- PR documental: `https://github.com/jl1dvg/altavision52/pull/55`.
+- MedForge repo: `/Users/jorgeluisdevera/PhpstormProjects/MedForge`, `origin/staging=08f85d29c9f011d3c139ab56e3a6f0082c7a6d4d`.
+- Notion Knowledge OS: Protocolo Codex / Claude Code y Operational Core - Inventario Maestro.
+- Base de datos viva OpenEMR: acceso autorizado por Jorge, pero no disponible localmente; `sites/default/sqlconf.php` existe y es el origen de credenciales de OpenEMR, pero la conexion fallo con `DB_ERROR_CODE=2002`. `requires verification`.
+- Revision Claude Code MedForge: PR `https://github.com/jl1dvg/MedForge/pull/1065`, recomendacion `APPROVE WITH CHANGES`.
+
+## Estado del contrato
+
+`patient-v1` permanece **Draft**. La aprobacion actual es "revision con cambios", no autorizacion de implementacion ni piloto. No puede pasar a `Accepted` hasta completar los criterios del contrato consolidado.
+
+1. Dump estructural sin datos de la base Alta Vision OpenEMR.
+2. Acceso read-only a la base real.
+3. Salida agregada de los comandos SQL read-only documentados en `contracts/patient-v1.md`.
+
+No se aceptan fixtures con datos reales ni muestras con PII.
+
+## Roadmap de ejecucion
+
+1. Dominio Pacientes: cerrar contrato `patient-v1`, identidad clinica MedForge y piloto 20 pacientes anonimizados. Estado: Draft bloqueado por verificacion DB y deuda de unicidad de `core_external_aliases`.
+2. Dominio Encuentros/Consultas: mapear `forms.form_id`, `form_eye_base`, `consulta_data` y `core_episode_id`.
+3. Dominio Procedimientos proyectados: mapear `procedimiento_proyectado`, sedes, provider y estados legacy.
+4. Dominio Protocolos/Cirugias: mapear `protocolo_data`, formularios quirurgicos, insumos, diagnosticos y firmantes.
+5. Dominio Facturacion: mapear dependencias por `hc_number` + `form_id`, derivaciones, afiliacion y reglas financieras.
+6. Pilotos incrementales anonimizados: 20 pacientes, luego 100, luego lote controlado con aprobacion explicita de Jorge.
+
+## Reglas de seguridad
+
+- No copiar PHI a Notion ni a contratos.
+- No ejecutar migracion masiva desde este programa sin aprobacion de Jorge.
+- No modificar datos reales desde tareas de auditoria.
+- Toda decision clinica, cambio funcional o tratamiento de datos reales debe escalarse a Jorge.
+- `hc_number`, `pid`, `pubpid` y `form_id` son aliases externos o llaves legacy; no son identidad soberana de MedForge.
+
+## Artefactos vigentes
+
+- `contracts/patient-v1.md`: contrato humano consolidado, fuente unica de estado, decisiones, mapping, riesgos, rollback, piloto y handoff.
+- `contracts/patient-v1.schema.json`: contrato tecnico JSON Schema para payloads.

--- a/docs/openemr-medforge-migration/contracts/patient-v1.md
+++ b/docs/openemr-medforge-migration/contracts/patient-v1.md
@@ -4,10 +4,99 @@ Estado: Draft.
 Decision de Jorge: revision con cambios aprobada; no se autoriza implementacion, piloto ni migracion.
 Fecha de consolidacion: 2026-07-31.
 
+## 0. Addendum Fase 1.3 - decisiones vigentes
+
+Fecha local Ecuador: 2026-07-30.
+Fecha UTC de artefactos remotos: 2026-07-31.
+
+Este addendum prevalece sobre secciones anteriores si hay conflicto.
+
+Decisiones arquitectonicas aprobadas por Jorge:
+
+- Alta Vision utilizara una instancia clinica y una base de datos independientes. Puede compartir infraestructura fisica o VPS, pero no tablas clinicas ni base de datos clinica con otras organizaciones.
+- `core_patients` no incorporara `organization_id` ni `instance_id`; el aislamiento clinico sera por despliegue/base de datos.
+- Control Center registrara organizacion, instancia, ambiente y servicios de Alta Vision.
+- `core_patients.id` sera la identidad clinica soberana.
+- `pid`, `pubpid`, `hc_number`, `form_id` y demas identificadores externos seran aliases o senales externas.
+- La cedula no sera restriccion `UNIQUE` directa en `core_patients`; sera senal fuerte de vinculacion solo cuando este normalizada y verificada.
+- Coincidencias ambiguas quedan en revision manual; no se fusionan pacientes automaticamente.
+- OpenEMR/Patient V1 debe reutilizar y extender la arquitectura Provider existente. No se autoriza crear un mecanismo paralelo de resolucion de identidad.
+
+Slugs propuestos para Control Center:
+
+- Organizacion: `alta-vision`.
+- Instancia MedForge Staging: `altavision-staging`.
+- Instancia MedForge Produccion: `altavision-production`.
+- `source_system=openemr`.
+- `source_instance=altavision-openemr-production`.
+- No utilizar dato demo como identidad definitiva.
+
+Estado de verificacion estructural OpenEMR:
+
+- VPS accesible por SSH con alias `altavision-vps`; `altavision_vps` no resolvio en este entorno.
+- Vhost activo: `app.alta-vision.com`.
+- Document root activo: `/var/www/html/altavision`.
+- Config DB OpenEMR: `/var/www/html/altavision/sites/default/sqlconf.php`.
+- Esquema activo verificado por hash `defe7bcf4b072b0b`.
+- Conexion DB: `ok`.
+- Escrituras ejecutadas: ninguna.
+- PII publicada: ninguna.
+- Total `patient_data`: 22.653.
+
+Hallazgos Pacientes sin PII:
+
+- `patient_data.pid`: 22.653 distintos, 0 vacios, 0 duplicados. Alias deterministico principal `openemr_pid`.
+- `patient_data.id`: 22.653 distintos, 0 vacios, 0 duplicados. Alias deterministico secundario `openemr_patient_data_id`.
+- `patient_data.pubpid`: 5 vacios, 30 grupos duplicados, 60 filas en grupos duplicados. No puede ser llave unica.
+- `patient_data.hc_number`: no existe.
+- `patient_data.ss`: existe pero esta vacio en todos los pacientes verificados; no permite validar cedula desde esta fuente.
+- `patient_data.lname2`: existe en base real y no esta en el `CREATE TABLE patient_data` base local; personalizacion/drift real.
+- `patient_data.hipaa_allowwhatsapp`: existe y esta versionado en `sql/6_0_0-to-whatsapp_allow-idempotent.sql`.
+- `DOB`: 32 vacios, 6 futuros, 10 anteriores a 1900; requiere normalizacion/revision.
+- `email` y telefonos tienen vacios, duplicados y formas invalidas; no deben usarse como identidad soberana.
+
+Relaciones agregadas:
+
+- `form_encounter`: 84.971 filas, 20.936 pacientes enlazados.
+- `forms`: 233.128 filas, 20.936 pacientes enlazados.
+- `documents`: 14.997 filas.
+- `openemr_postcalendar_events`: 95.974 filas, 21.242 pacientes enlazados.
+- `billing`: 906.240 filas, 10.525 pacientes enlazados.
+- `transactions`: 5.469 filas, 3.131 pacientes enlazados.
+- `lists`: 22.331 filas, 12.038 pacientes enlazados.
+- `pnotes`: 19 filas, 11 pacientes enlazados.
+
+Tablas no presentes en el esquema activo:
+
+- `consulta_data`.
+- `procedimiento_proyectado`.
+- `protocolo_data`.
+- `appointments`.
+
+Reglas de resolucion de identidad Patient V1:
+
+- Resolver primero aliases exactos existentes en `core_external_aliases` filtrando por `aliasable_type=Patient`.
+- Crear o vincular `core_patients.id` solo despues de una resolucion deterministica o revision aprobada.
+- `openemr_pid` y `openemr_patient_data_id` son deterministas dentro de `source_instance=altavision-openemr-production`.
+- `openemr_pubpid` es alias fuerte no deterministico por duplicados/vacios.
+- Cedula normalizada/verificada es senal fuerte; si hay ambiguedad, `manual_review_status=required`.
+- No fusionar pacientes automaticamente.
+- Todo lote debe usar `batch_id`, `source_instance`, conteos agregados, fingerprints y modo idempotente.
+- Reruns no deben duplicar pacientes ni aliases.
+
+Bloqueantes para `Accepted`:
+
+1. Aprobar o implementar el PR P0 independiente de MedForge que corrige la unicidad de `core_external_aliases`.
+2. Preparar formalmente organizacion e instancias Alta Vision en Control Center.
+3. Actualizar fixtures sinteticos del piloto.
+4. Revision final de Jorge.
+
+Decision de readiness Fase 1.3: Patient V1 permanece Draft.
+
 ## 1. Fuentes
 
-- OpenEMR/AltaVision: `altavision52`, rama documental `codex/altavision-patient-v1-contract`.
-- PR OpenEMR/AltaVision: `https://github.com/jl1dvg/altavision52/pull/55`.
+- OpenEMR/AltaVision: `altavision52`, rama documental limpia `codex/altavision-patient-v1-contract-clean`; rama Fase 1.3 `codex/altavision-phase-1-3-patient-readiness`.
+- PR OpenEMR/AltaVision vigente: `https://github.com/jl1dvg/altavision52/pull/56`. PR `#55` queda supersedido.
 - MedForge: `origin/staging=08f85d29c9f011d3c139ab56e3a6f0082c7a6d4d`.
 - Revision Claude Code: `https://github.com/jl1dvg/MedForge/pull/1065`, recomendacion `APPROVE WITH CHANGES`.
 - Notion: Programa Alta Vision Migracion OpenEMR a MedForge, Operational Core, Control Center, ADR Provider.
@@ -18,10 +107,10 @@ No se copio PII a este contrato. No se extrajeron filas reales de pacientes.
 
 Patient V1 sigue Draft por estos bloqueantes:
 
-- Base OpenEMR real no verificada. El acceso fue autorizado, pero la conexion local fallo con `DB_ERROR_CODE=2002`.
-- Falta dump estructural sin datos, acceso read-only efectivo o metricas agregadas verificables.
-- La deuda de unicidad polimorfica de `core_external_aliases` debe auditarse antes de modificar esquema.
-- No se ha preparado ni registrado la instancia real de Alta Vision en Control Center.
+- Base OpenEMR real verificada parcialmente por estructura y metricas agregadas desde VPS, sin PII y sin escrituras.
+- Falta aprobar o implementar la correccion P0 de unicidad polimorfica de `core_external_aliases`.
+- No se ha preparado ni registrado formalmente la organizacion/instancias reales de Alta Vision en Control Center.
+- Falta definir fixtures sinteticos del piloto.
 - No se autoriza implementacion ni piloto.
 
 ## 3. Decisiones aceptadas
@@ -29,11 +118,14 @@ Patient V1 sigue Draft por estos bloqueantes:
 - Alta Vision usara una instancia logica y base de datos independiente para informacion clinica.
 - Puede compartir infraestructura fisica con otros despliegues.
 - No se usara una base clinica multi-tenant compartida en esta fase.
+- `core_patients` no incorporara `organization_id` ni `instance_id`; el aislamiento clinico se hara por despliegue y base de datos.
+- Control Center registrara organizacion, instancia, ambiente y servicios de Alta Vision.
 - Patient V1 reutilizara y extendera la arquitectura Provider existente.
 - No se autoriza crear un subsistema paralelo de identidad de pacientes.
 - `core_patients.id` es la identidad soberana del paciente en MedForge.
 - `pid`, `pubpid`, `hc_number`, cedula y `form_id` son aliases o senales externas.
 - `form_id` pertenece principalmente a formulario/episodio legacy; no debe ser identidad primaria de paciente.
+- La cedula no sera restriccion `UNIQUE` directa en `core_patients`; sera senal fuerte de vinculacion solo cuando este normalizada y verificada.
 - La preparacion de la instancia real de Alta Vision en Control Center esta autorizada; su ejecucion no.
 
 ## 4. Decisiones rechazadas
@@ -58,7 +150,7 @@ Campos logicos del contrato:
 - `organization_id`: `control_center_organizations.id`, cuando exista.
 - `instance_id`: `control_center_instances.id`, cuando exista.
 - `organization_slug`: slug de organizacion, por ejemplo `alta-vision`.
-- `instance_slug`: slug de instancia Control Center, por ejemplo `alta-vision-production`.
+- `instance_slug`: slug de instancia MedForge/Control Center, por ejemplo `altavision-production`.
 - `environment`: `production` o `staging`.
 - `source_system`: `openemr`.
 - `source_instance`: identificador logico de origen, por ejemplo `altavision-openemr-production`.
@@ -67,9 +159,9 @@ Campos logicos del contrato:
 
 ## 6. Regla de unicidad
 
-Regla logica deseada:
+Regla logica deseada para aliases Patient:
 
-`instance_id + source_system + source_instance + external_type + external_value` debe resolver a un solo paciente.
+`aliasable_type + instance_slug + provider + external_type + external_id` debe resolver a un solo paciente.
 
 Implementacion actual en MedForge:
 
@@ -79,8 +171,9 @@ Implementacion actual en MedForge:
 
 Conclusion:
 
-- Antes de modificar esquema o escribir aliases Patient, debe auditarse la deuda transversal de unicidad polimorfica.
-- Cualquier cambio requiere ADR corta del Core porque afecta un contrato ya usado por Sede/CIVE.
+- Antes de escribir aliases Patient, debe corregirse la deuda P0 transversal de unicidad polimorfica.
+- La nueva unicidad minima debe incluir `aliasable_type`, `instance_slug`, `provider`, `external_type`, `external_id`.
+- No debe incluir `aliasable_id`.
 - Mientras tanto, Patient V1 debe namespaciar `external_type` y filtrar por `aliasable_type` en todo resolver.
 
 ## 7. Mapping OpenEMR/AltaVision
@@ -91,14 +184,16 @@ Conclusion:
 | `patient_data.id` | alias `openemr_patient_data_id` | Aceptado como alias externo |
 | `patient_data.pubpid` | alias `openemr_pubpid` | Aceptado como alias externo |
 | `patient_data.fname/mname/lname` | `core_patients.full_name` + datos demograficos de contrato | Draft |
+| `patient_data.lname2` | `core_patients.second_last_name` o componente de nombre | Personalizacion real verificada |
 | `patient_data.DOB` | `core_patients.birth_date` | Draft |
 | `patient_data.sex` | `core_patients.sex` | Pendiente catalogo Jorge |
 | `patient_data.phone_*`, `email` | perfil/contactos fuera de Core minimo | Draft |
 | `patient_data.pricelevel`, `financial`, `billing_note` | fuera de Patient V1; futuro `billing-v1` | Aceptado fuera de alcance |
 | `forms.form_id` | alias de formulario/episodio, no paciente | Aceptado |
-| MedForge `patient_data.hc_number` | alias `hc_number` | Aceptado como legacy |
+| `patient_data.hc_number` | alias `hc_number` | No existe en base real verificada |
+| `patient_data.hipaa_allowwhatsapp` | consentimiento/contactabilidad | Personalizacion real versionada |
 
-## 8. Verificacion OpenEMR pendiente
+## 8. Verificacion OpenEMR
 
 OpenEMR inicializa DB asi:
 
@@ -108,7 +203,7 @@ OpenEMR inicializa DB asi:
 
 No exponer credenciales en logs, commits, Notion ni respuestas.
 
-Artefacto preferido:
+La Fase 1.3 ya verifico estructura y metricas agregadas del esquema activo de Pacientes. Si se requiere reproducibilidad externa adicional, el artefacto preferido sigue siendo:
 
 ```bash
 mysqldump --no-data --skip-comments --single-transaction --default-character-set=utf8mb4 -u READONLY_USER -p -h DB_HOST --port=DB_PORT DB_NAME > altavision-openemr-schema.sql
@@ -156,14 +251,15 @@ Archivos probables MedForge:
 - `laravel-app/app/Modules/Core/Services/PatientIdentityResolver.php` o generalizacion equivalente.
 - `laravel-app/app/Console/Commands/PatientsValidateContract.php`.
 - Tests bajo `laravel-app/tests/Feature/Core/`.
-- Migracion correctiva de `core_external_aliases` solo despues de ADR/auditoria.
+- La migracion correctiva de `core_external_aliases` debe ir en PR P0 independiente antes del importador OpenEMR.
+- Especificacion autocontenida: `docs/openemr-medforge-migration/handoffs/medforge-core-alias-uniqueness-p0.md`.
 
 ## 10. Preparacion Control Center autorizada
 
 Autorizado:
 
 - Preparar comandos, parametros y checklist para registrar Alta Vision como organizacion/instancia.
-- Revisar `instance:create`.
+- Revisar superficie vigente de Control Center.
 - Documentar valores requeridos.
 
 No autorizado:
@@ -172,30 +268,53 @@ No autorizado:
 - Crear registros reales en Control Center.
 - Desplegar infraestructura.
 
+Propuesta formal:
+
+- Organizacion: `alta-vision`.
+- Instancia MedForge Staging: `altavision-staging`.
+- Instancia MedForge Produccion: `altavision-production`.
+- Ambiente Staging: `staging`.
+- Ambiente Produccion: `production`.
+- Sistema fuente: `openemr`.
+- Instancia fuente: `altavision-openemr-production`.
+- No usar dato demo como identidad definitiva.
+
+Superficie MedForge verificada contra repo local:
+
+- Ruta crear organizacion: `POST /v2/control-center/organizations`.
+- Ruta crear instancia: `POST /v2/control-center/instances`.
+- Controlador: `laravel-app/app/Modules/ControlCenter/Http/Controllers/ControlCenterApiController.php`.
+- Servicio: `laravel-app/app/Modules/ControlCenter/Services/ControlCenterService.php`.
+- No se ejecuto ninguna llamada ni se crearon registros reales.
+
 ## 11. Riesgos
 
 | Riesgo | Estado | Mitigacion |
 |---|---|---|
-| DB OpenEMR no verificada | Abierto | dump estructural o acceso read-only efectivo |
+| DB OpenEMR no verificada | Parcialmente cerrado | estructura y metricas agregadas verificadas por VPS, sin PII |
+| `pubpid` duplicado | Abierto | no usar como llave deterministica unica; alias fuerte con revision |
+| Fechas DOB inconsistentes | Abierto | normalizacion y reglas de rechazo/revision en piloto sintetico |
+| Contactos/email inconsistentes | Abierto | fuera de identidad soberana; limpiar en dominio contactos futuro |
 | PII en artefactos | Controlado | solo estructura/agregados; fixtures sinteticos |
-| Colision polimorfica en `core_external_aliases` | Abierto prioritario | ADR + auditoria antes de modificar esquema |
+| Colision polimorfica en `core_external_aliases` | P0 abierto | PR independiente Core antes de importador |
 | Subsistema paralelo de identidad | Rechazado | extender Provider/Identity resolver |
 | CIVE/SigCenter heredado por Alta Vision | Controlado en diseno | instancia explicita, fail-closed |
 | Facturacion mezclada con Patient | Controlado | fuera de alcance; futuro `billing-v1` |
 
 ## 12. Criterios para pasar a Accepted
 
-- Dump estructural sin datos o acceso read-only verificado.
-- Calidad de datos agregada documentada sin PII.
-- Columnas personalizadas reales identificadas.
-- Instancia Alta Vision preparada en Control Center y aprobada para ejecucion.
-- Deuda de unicidad de `core_external_aliases` auditada y con ADR.
-- Claude/Codex consolidados en este contrato unico.
-- Jorge aprueba pasar de Draft a Accepted.
+- Esquema real OpenEMR verificado y documentado sin PII. Estado: parcialmente cumplido en Fase 1.3.
+- Calidad de datos agregada documentada sin PII. Estado: cumplido para Pacientes.
+- Columnas personalizadas reales identificadas. Estado: parcialmente cumplido; `lname2` y `hipaa_allowwhatsapp` verificados.
+- Instancia Alta Vision preparada en Control Center y aprobada para ejecucion. Estado: pendiente.
+- Deuda P0 de unicidad de `core_external_aliases` aprobada o implementada. Estado: pendiente.
+- Contrato actualizado conforme a arquitectura Provider. Estado: cumplido documentalmente, pendiente revision MedForge despues del PR P0.
+- Fixtures sinteticos del piloto definidos. Estado: pendiente.
+- Jorge aprueba pasar de Draft a Accepted. Estado: pendiente.
 
 ## 13. Rollback
 
-Dry-run: descartar artefactos temporales.
+Dry-run: descartar artefactos temporales y reportes locales.
 
 Si en una fase futura Jorge autoriza escritura en ambiente temporal:
 
@@ -204,6 +323,12 @@ Si en una fase futura Jorge autoriza escritura en ambiente temporal:
 3. Revertir datos derivados del batch.
 4. Eliminar solo pacientes sin vinculos externos al batch.
 5. Bloquear borrado si hay episodios, facturas, consultas, protocolos o aliases ajenos al batch.
+
+Reconciliacion:
+
+- Todo batch genera conteos por `created`, `matched_existing`, `manual_review_required`, `rejected`, `unchanged`.
+- Un rerun con el mismo `batch_id` y fingerprints no debe duplicar aliases ni pacientes.
+- Cualquier divergencia entre OpenEMR y MedForge queda como evento de reconciliacion, no como overwrite automatico.
 
 ## 14. Piloto 20 pacientes
 

--- a/docs/openemr-medforge-migration/contracts/patient-v1.md
+++ b/docs/openemr-medforge-migration/contracts/patient-v1.md
@@ -17,8 +17,13 @@ Decisiones arquitectonicas aprobadas por Jorge:
 - `core_patients` no incorporara `organization_id` ni `instance_id`; el aislamiento clinico sera por despliegue/base de datos.
 - Control Center registrara organizacion, instancia, ambiente y servicios de Alta Vision.
 - `core_patients.id` sera la identidad clinica soberana.
-- `pid`, `pubpid`, `hc_number`, `form_id` y demas identificadores externos seran aliases o senales externas.
-- La cedula no sera restriccion `UNIQUE` directa en `core_patients`; sera senal fuerte de vinculacion solo cuando este normalizada y verificada.
+- `patient_data.pid` de OpenEMR es el identificador interno tecnico del paciente en OpenEMR y se conserva como alias externo obligatorio/deterministico asociado posteriormente a `core_patients.id`.
+- `patient_data.pubpid` de OpenEMR equivale funcionalmente a `patient_data.hc_number` de MedForge.
+- `pubpid`, `hc_number` y cedula representan el mismo concepto funcional: cedula o numero de identificacion del paciente.
+- `patient_data.lname2` se mapea directamente a `patient_data.lname2` de MedForge.
+- `patient_data.id` de MedForge seguira siendo identificador tecnico de tabla legacy, no identidad universal.
+- `form_id` y demas identificadores de formularios son aliases o llaves legacy de formularios/episodios, no identidad primaria de paciente.
+- La cedula/`pubpid`/`hc_number` no sera restriccion `UNIQUE` directa en `core_patients`; sera senal fuerte de vinculacion solo cuando este normalizada y verificada.
 - Coincidencias ambiguas quedan en revision manual; no se fusionan pacientes automaticamente.
 - OpenEMR/Patient V1 debe reutilizar y extender la arquitectura Provider existente. No se autoriza crear un mecanismo paralelo de resolucion de identidad.
 
@@ -45,11 +50,11 @@ Estado de verificacion estructural OpenEMR:
 
 Hallazgos Pacientes sin PII:
 
-- `patient_data.pid`: 22.653 distintos, 0 vacios, 0 duplicados. Alias deterministico principal `openemr_pid`.
+- `patient_data.pid`: 22.653 distintos, 0 vacios, 0 duplicados. Alias tecnico obligatorio y deterministico `openemr_pid`.
 - `patient_data.id`: 22.653 distintos, 0 vacios, 0 duplicados. Alias deterministico secundario `openemr_patient_data_id`.
-- `patient_data.pubpid`: 5 vacios, 30 grupos duplicados, 60 filas en grupos duplicados. No puede ser llave unica.
-- `patient_data.hc_number`: no existe.
-- `patient_data.ss`: existe pero esta vacio en todos los pacientes verificados; no permite validar cedula desde esta fuente.
+- `patient_data.pubpid`: equivale funcionalmente a `patient_data.hc_number` de MedForge; representa cedula/numero de identificacion. Tiene 5 vacios, 30 grupos duplicados y 60 filas en grupos duplicados; no puede producir fusion automatica.
+- `patient_data.hc_number`: no existe en OpenEMR; el campo equivalente en MedForge se alimentaria desde `patient_data.pubpid` cuando sea valido.
+- `patient_data.ss`: existe pero esta vacio en todos los pacientes verificados; no es fuente util para cedula/identificacion en Alta Vision.
 - `patient_data.lname2`: existe en base real y no esta en el `CREATE TABLE patient_data` base local; personalizacion/drift real.
 - `patient_data.hipaa_allowwhatsapp`: existe y esta versionado en `sql/6_0_0-to-whatsapp_allow-idempotent.sql`.
 - `DOB`: 32 vacios, 6 futuros, 10 anteriores a 1900; requiere normalizacion/revision.
@@ -78,8 +83,11 @@ Reglas de resolucion de identidad Patient V1:
 - Resolver primero aliases exactos existentes en `core_external_aliases` filtrando por `aliasable_type=Patient`.
 - Crear o vincular `core_patients.id` solo despues de una resolucion deterministica o revision aprobada.
 - `openemr_pid` y `openemr_patient_data_id` son deterministas dentro de `source_instance=altavision-openemr-production`.
-- `openemr_pubpid` es alias fuerte no deterministico por duplicados/vacios.
-- Cedula normalizada/verificada es senal fuerte; si hay ambiguedad, `manual_review_status=required`.
+- `openemr_pubpid` es el alias/fuente funcional de `hc_number`/cedula/identificacion.
+- `pubpid` valido: mapear a `patient_data.hc_number` en MedForge y registrar como senal fuerte.
+- `pubpid` vacio: marcar paciente como pendiente de politica de identificacion.
+- `pubpid` duplicado: marcar conflicto y `manual_review_status=required`.
+- Nunca fusionar pacientes automaticamente por coincidencia de `pubpid`/`hc_number`/cedula.
 - No fusionar pacientes automaticamente.
 - Todo lote debe usar `batch_id`, `source_instance`, conteos agregados, fingerprints y modo idempotente.
 - Reruns no deben duplicar pacientes ni aliases.
@@ -96,7 +104,9 @@ Decision de readiness Fase 1.3: Patient V1 permanece Draft.
 ## 1. Fuentes
 
 - OpenEMR/AltaVision: `altavision52`, rama documental limpia `codex/altavision-patient-v1-contract-clean`; rama Fase 1.3 `codex/altavision-phase-1-3-patient-readiness`.
-- PR OpenEMR/AltaVision vigente: `https://github.com/jl1dvg/altavision52/pull/56`. PR `#55` queda supersedido.
+- PR OpenEMR/AltaVision canonico vigente: `https://github.com/jl1dvg/altavision52/pull/57`, hacia `master`.
+- PR `#56` queda superseded porque `#57` contiene todo su contenido mas las actualizaciones posteriores.
+- PR `#55` queda supersedido por contaminacion historica de commits no relacionados.
 - MedForge: `origin/staging=08f85d29c9f011d3c139ab56e3a6f0082c7a6d4d`.
 - Revision Claude Code: `https://github.com/jl1dvg/MedForge/pull/1065`, recomendacion `APPROVE WITH CHANGES`.
 - Notion: Programa Alta Vision Migracion OpenEMR a MedForge, Operational Core, Control Center, ADR Provider.
@@ -123,7 +133,9 @@ Patient V1 sigue Draft por estos bloqueantes:
 - Patient V1 reutilizara y extendera la arquitectura Provider existente.
 - No se autoriza crear un subsistema paralelo de identidad de pacientes.
 - `core_patients.id` es la identidad soberana del paciente en MedForge.
-- `pid`, `pubpid`, `hc_number`, cedula y `form_id` son aliases o senales externas.
+- `patient_data.pid` de OpenEMR es alias tecnico obligatorio y deterministico.
+- `patient_data.pubpid`, `patient_data.hc_number` de MedForge y cedula son el mismo concepto funcional de identificacion del paciente.
+- `form_id` es alias/llave legacy de formulario o episodio, no identidad primaria de paciente.
 - `form_id` pertenece principalmente a formulario/episodio legacy; no debe ser identidad primaria de paciente.
 - La cedula no sera restriccion `UNIQUE` directa en `core_patients`; sera senal fuerte de vinculacion solo cuando este normalizada y verificada.
 - La preparacion de la instancia real de Alta Vision en Control Center esta autorizada; su ejecucion no.
@@ -154,7 +166,7 @@ Campos logicos del contrato:
 - `environment`: `production` o `staging`.
 - `source_system`: `openemr`.
 - `source_instance`: identificador logico de origen, por ejemplo `altavision-openemr-production`.
-- `external_type`: alias namespaced, por ejemplo `openemr_pid`, `openemr_pubpid`, `openemr_patient_data_id`, `hc_number`.
+- `external_type`: alias namespaced, por ejemplo `openemr_pid`, `openemr_pubpid`, `openemr_patient_data_id`. `openemr_pubpid` representa el valor funcional que MedForge expone como `patient_data.hc_number`.
 - `external_value`: valor normalizado; no se publica en Notion ni fixtures si contiene PII.
 
 ## 6. Regla de unicidad
@@ -180,18 +192,26 @@ Conclusion:
 
 | OpenEMR/AltaVision | MedForge propuesto | Estado |
 |---|---|---|
-| `patient_data.pid` | alias `openemr_pid` | Aceptado como alias externo |
-| `patient_data.id` | alias `openemr_patient_data_id` | Aceptado como alias externo |
-| `patient_data.pubpid` | alias `openemr_pubpid` | Aceptado como alias externo |
+| `patient_data.pid` | alias `openemr_pid` asociado a `core_patients.id` | Aceptado como alias tecnico obligatorio y deterministico |
+| `patient_data.id` | identificador tecnico legacy / alias `openemr_patient_data_id` si se necesita trazabilidad | Aceptado; no identidad universal |
+| `patient_data.pubpid` | `patient_data.hc_number` de MedForge + alias `openemr_pubpid` | Aceptado como cedula/numero de identificacion |
 | `patient_data.fname/mname/lname` | `core_patients.full_name` + datos demograficos de contrato | Draft |
-| `patient_data.lname2` | `core_patients.second_last_name` o componente de nombre | Personalizacion real verificada |
+| `patient_data.lname2` | `patient_data.lname2` de MedForge | Mapeo directo confirmado |
 | `patient_data.DOB` | `core_patients.birth_date` | Draft |
 | `patient_data.sex` | `core_patients.sex` | Pendiente catalogo Jorge |
 | `patient_data.phone_*`, `email` | perfil/contactos fuera de Core minimo | Draft |
 | `patient_data.pricelevel`, `financial`, `billing_note` | fuera de Patient V1; futuro `billing-v1` | Aceptado fuera de alcance |
 | `forms.form_id` | alias de formulario/episodio, no paciente | Aceptado |
-| `patient_data.hc_number` | alias `hc_number` | No existe en base real verificada |
+| `patient_data.hc_number` | no aplica en OpenEMR; equivalente funcional es `patient_data.pubpid` | Confirmado por Jorge |
 | `patient_data.hipaa_allowwhatsapp` | consentimiento/contactabilidad | Personalizacion real versionada |
+
+Reglas de `pubpid` / `hc_number` / cedula:
+
+- Valor valido: mapear `patient_data.pubpid` de OpenEMR a `patient_data.hc_number` de MedForge.
+- Valor vacio: paciente pendiente de politica de identificacion; no bloquear `openemr_pid`.
+- Valor duplicado: conflicto que requiere revision manual.
+- Nunca fusionar pacientes automaticamente por coincidencia de identificacion.
+- `core_patients.id` sigue siendo identidad soberana incluso cuando `hc_number` exista.
 
 ## 8. Verificacion OpenEMR
 
@@ -243,7 +263,7 @@ Cuando Jorge autorice implementacion:
 - Ejecutar dry-run por defecto.
 - Reportar conteos, fingerprints y razones de revision; nunca PII.
 - Bloquear duplicados de alias.
-- No cambiar lecturas legacy por `hc_number`.
+- No tratar `pubpid`, `hc_number` y cedula como conceptos distintos; son el mismo identificador funcional con nombres distintos por sistema.
 - No tocar Billing, Agenda, WhatsApp, Solicitudes, Cirugias ni Reporting en esta fase.
 
 Archivos probables MedForge:
@@ -292,7 +312,7 @@ Superficie MedForge verificada contra repo local:
 | Riesgo | Estado | Mitigacion |
 |---|---|---|
 | DB OpenEMR no verificada | Parcialmente cerrado | estructura y metricas agregadas verificadas por VPS, sin PII |
-| `pubpid` duplicado | Abierto | no usar como llave deterministica unica; alias fuerte con revision |
+| `pubpid`/`hc_number` duplicado | Abierto | conflicto de identificacion; revision manual; nunca merge automatico |
 | Fechas DOB inconsistentes | Abierto | normalizacion y reglas de rechazo/revision en piloto sintetico |
 | Contactos/email inconsistentes | Abierto | fuera de identidad soberana; limpiar en dominio contactos futuro |
 | PII en artefactos | Controlado | solo estructura/agregados; fixtures sinteticos |

--- a/docs/openemr-medforge-migration/contracts/patient-v1.md
+++ b/docs/openemr-medforge-migration/contracts/patient-v1.md
@@ -1,0 +1,219 @@
+# Patient V1 - contrato consolidado
+
+Estado: Draft.
+Decision de Jorge: revision con cambios aprobada; no se autoriza implementacion, piloto ni migracion.
+Fecha de consolidacion: 2026-07-31.
+
+## 1. Fuentes
+
+- OpenEMR/AltaVision: `altavision52`, rama documental `codex/altavision-patient-v1-contract`.
+- PR OpenEMR/AltaVision: `https://github.com/jl1dvg/altavision52/pull/55`.
+- MedForge: `origin/staging=08f85d29c9f011d3c139ab56e3a6f0082c7a6d4d`.
+- Revision Claude Code: `https://github.com/jl1dvg/MedForge/pull/1065`, recomendacion `APPROVE WITH CHANGES`.
+- Notion: Programa Alta Vision Migracion OpenEMR a MedForge, Operational Core, Control Center, ADR Provider.
+
+No se copio PII a este contrato. No se extrajeron filas reales de pacientes.
+
+## 2. Estado Draft
+
+Patient V1 sigue Draft por estos bloqueantes:
+
+- Base OpenEMR real no verificada. El acceso fue autorizado, pero la conexion local fallo con `DB_ERROR_CODE=2002`.
+- Falta dump estructural sin datos, acceso read-only efectivo o metricas agregadas verificables.
+- La deuda de unicidad polimorfica de `core_external_aliases` debe auditarse antes de modificar esquema.
+- No se ha preparado ni registrado la instancia real de Alta Vision en Control Center.
+- No se autoriza implementacion ni piloto.
+
+## 3. Decisiones aceptadas
+
+- Alta Vision usara una instancia logica y base de datos independiente para informacion clinica.
+- Puede compartir infraestructura fisica con otros despliegues.
+- No se usara una base clinica multi-tenant compartida en esta fase.
+- Patient V1 reutilizara y extendera la arquitectura Provider existente.
+- No se autoriza crear un subsistema paralelo de identidad de pacientes.
+- `core_patients.id` es la identidad soberana del paciente en MedForge.
+- `pid`, `pubpid`, `hc_number`, cedula y `form_id` son aliases o senales externas.
+- `form_id` pertenece principalmente a formulario/episodio legacy; no debe ser identidad primaria de paciente.
+- La preparacion de la instancia real de Alta Vision en Control Center esta autorizada; su ejecucion no.
+
+## 4. Decisiones rechazadas
+
+- Rechazado: base clinica multi-tenant compartida para Alta Vision en esta fase.
+- Rechazado: crear `PatientContractImportService` o cualquier flujo paralelo que duplique `ProviderIdentityResolver`/`AliasResolution`.
+- Rechazado: ejecutar piloto con datos reales o anonimizados antes de verificar OpenEMR.
+- Rechazado: escribir en bases productivas desde esta fase.
+
+## 5. Arquitectura destino
+
+La solucion debe extender el patron Provider:
+
+- Reutilizar `core_external_aliases`.
+- Reutilizar o generalizar `ProviderIdentityResolver`.
+- Reutilizar o generalizar `AliasResolution`, `ProviderSignal` y `ProviderResolution`.
+- Mantener confirmacion/revision humana para conflictos.
+- Mantener dry-run como default.
+
+Campos logicos del contrato:
+
+- `organization_id`: `control_center_organizations.id`, cuando exista.
+- `instance_id`: `control_center_instances.id`, cuando exista.
+- `organization_slug`: slug de organizacion, por ejemplo `alta-vision`.
+- `instance_slug`: slug de instancia Control Center, por ejemplo `alta-vision-production`.
+- `environment`: `production` o `staging`.
+- `source_system`: `openemr`.
+- `source_instance`: identificador logico de origen, por ejemplo `altavision-openemr-production`.
+- `external_type`: alias namespaced, por ejemplo `openemr_pid`, `openemr_pubpid`, `openemr_patient_data_id`, `hc_number`.
+- `external_value`: valor normalizado; no se publica en Notion ni fixtures si contiene PII.
+
+## 6. Regla de unicidad
+
+Regla logica deseada:
+
+`instance_id + source_system + source_instance + external_type + external_value` debe resolver a un solo paciente.
+
+Implementacion actual en MedForge:
+
+- `core_external_aliases` usa `instance_slug`, `provider`, `external_type`, `external_id`.
+- La restriccion vigente no incluye `aliasable_type`/`aliasable_id`.
+- La tabla es polimorfica y ya la usan Patient y Sede.
+
+Conclusion:
+
+- Antes de modificar esquema o escribir aliases Patient, debe auditarse la deuda transversal de unicidad polimorfica.
+- Cualquier cambio requiere ADR corta del Core porque afecta un contrato ya usado por Sede/CIVE.
+- Mientras tanto, Patient V1 debe namespaciar `external_type` y filtrar por `aliasable_type` en todo resolver.
+
+## 7. Mapping OpenEMR/AltaVision
+
+| OpenEMR/AltaVision | MedForge propuesto | Estado |
+|---|---|---|
+| `patient_data.pid` | alias `openemr_pid` | Aceptado como alias externo |
+| `patient_data.id` | alias `openemr_patient_data_id` | Aceptado como alias externo |
+| `patient_data.pubpid` | alias `openemr_pubpid` | Aceptado como alias externo |
+| `patient_data.fname/mname/lname` | `core_patients.full_name` + datos demograficos de contrato | Draft |
+| `patient_data.DOB` | `core_patients.birth_date` | Draft |
+| `patient_data.sex` | `core_patients.sex` | Pendiente catalogo Jorge |
+| `patient_data.phone_*`, `email` | perfil/contactos fuera de Core minimo | Draft |
+| `patient_data.pricelevel`, `financial`, `billing_note` | fuera de Patient V1; futuro `billing-v1` | Aceptado fuera de alcance |
+| `forms.form_id` | alias de formulario/episodio, no paciente | Aceptado |
+| MedForge `patient_data.hc_number` | alias `hc_number` | Aceptado como legacy |
+
+## 8. Verificacion OpenEMR pendiente
+
+OpenEMR inicializa DB asi:
+
+1. `interface/globals.php` define `OE_SITE_DIR`.
+2. `library/sqlconf.php` carga `sites/default/sqlconf.php`.
+3. `sites/default/sqlconf.php` define parametros de conexion.
+
+No exponer credenciales en logs, commits, Notion ni respuestas.
+
+Artefacto preferido:
+
+```bash
+mysqldump --no-data --skip-comments --single-transaction --default-character-set=utf8mb4 -u READONLY_USER -p -h DB_HOST --port=DB_PORT DB_NAME > altavision-openemr-schema.sql
+```
+
+Metricas agregadas permitidas sin PII:
+
+```sql
+SHOW COLUMNS FROM patient_data;
+SHOW COLUMNS FROM forms;
+SHOW COLUMNS FROM form_eye_base;
+SHOW COLUMNS FROM form_eye_mag_orders;
+SELECT COUNT(*) FROM patient_data;
+SELECT COUNT(*) FROM patient_data WHERE pid IS NULL OR pid = 0;
+SELECT COUNT(*) FROM (SELECT pid FROM patient_data GROUP BY pid HAVING COUNT(*) > 1) x;
+SELECT COUNT(*) FROM patient_data WHERE pubpid IS NULL OR TRIM(pubpid) = '';
+SELECT COUNT(*) FROM (SELECT pubpid FROM patient_data WHERE pubpid IS NOT NULL AND TRIM(pubpid) <> '' GROUP BY pubpid HAVING COUNT(*) > 1) x;
+SELECT COUNT(*) FROM patient_data WHERE DOB IS NULL OR DOB = '0000-00-00';
+SELECT COUNT(*) FROM patient_data WHERE DOB > CURDATE();
+SELECT COUNT(*) FROM patient_data WHERE DOB IS NOT NULL AND DOB <> '0000-00-00' AND DOB < '1900-01-01';
+SELECT COUNT(*) FROM patient_data WHERE sex IS NULL OR TRIM(sex) = '';
+SELECT COUNT(*) FROM patient_data WHERE phone_cell IS NULL OR TRIM(phone_cell) = '';
+SELECT COUNT(*) FROM patient_data WHERE email IS NULL OR TRIM(email) = '';
+SELECT COUNT(*) FROM patient_data WHERE email IS NOT NULL AND TRIM(email) <> '' AND email NOT LIKE '%_@_%._%';
+SELECT COUNT(*) FROM patient_data WHERE deceased_date IS NOT NULL OR TRIM(COALESCE(deceased_reason, '')) <> '';
+```
+
+## 9. Handoff MedForge futuro
+
+No implementar todavia.
+
+Cuando Jorge autorice implementacion:
+
+- Extender el patron `ProviderIdentityResolver`; no crear subsistema paralelo.
+- Validar `patient-v1.schema.json`.
+- Rechazar `instance_slug` que no exista en Control Center.
+- Ejecutar dry-run por defecto.
+- Reportar conteos, fingerprints y razones de revision; nunca PII.
+- Bloquear duplicados de alias.
+- No cambiar lecturas legacy por `hc_number`.
+- No tocar Billing, Agenda, WhatsApp, Solicitudes, Cirugias ni Reporting en esta fase.
+
+Archivos probables MedForge:
+
+- `laravel-app/app/Modules/Core/Services/PatientIdentityResolver.php` o generalizacion equivalente.
+- `laravel-app/app/Console/Commands/PatientsValidateContract.php`.
+- Tests bajo `laravel-app/tests/Feature/Core/`.
+- Migracion correctiva de `core_external_aliases` solo despues de ADR/auditoria.
+
+## 10. Preparacion Control Center autorizada
+
+Autorizado:
+
+- Preparar comandos, parametros y checklist para registrar Alta Vision como organizacion/instancia.
+- Revisar `instance:create`.
+- Documentar valores requeridos.
+
+No autorizado:
+
+- Ejecutar `instance:create`.
+- Crear registros reales en Control Center.
+- Desplegar infraestructura.
+
+## 11. Riesgos
+
+| Riesgo | Estado | Mitigacion |
+|---|---|---|
+| DB OpenEMR no verificada | Abierto | dump estructural o acceso read-only efectivo |
+| PII en artefactos | Controlado | solo estructura/agregados; fixtures sinteticos |
+| Colision polimorfica en `core_external_aliases` | Abierto prioritario | ADR + auditoria antes de modificar esquema |
+| Subsistema paralelo de identidad | Rechazado | extender Provider/Identity resolver |
+| CIVE/SigCenter heredado por Alta Vision | Controlado en diseno | instancia explicita, fail-closed |
+| Facturacion mezclada con Patient | Controlado | fuera de alcance; futuro `billing-v1` |
+
+## 12. Criterios para pasar a Accepted
+
+- Dump estructural sin datos o acceso read-only verificado.
+- Calidad de datos agregada documentada sin PII.
+- Columnas personalizadas reales identificadas.
+- Instancia Alta Vision preparada en Control Center y aprobada para ejecucion.
+- Deuda de unicidad de `core_external_aliases` auditada y con ADR.
+- Claude/Codex consolidados en este contrato unico.
+- Jorge aprueba pasar de Draft a Accepted.
+
+## 13. Rollback
+
+Dry-run: descartar artefactos temporales.
+
+Si en una fase futura Jorge autoriza escritura en ambiente temporal:
+
+1. Registrar `batch_id` o `source_fingerprint`.
+2. Revertir aliases del batch.
+3. Revertir datos derivados del batch.
+4. Eliminar solo pacientes sin vinculos externos al batch.
+5. Bloquear borrado si hay episodios, facturas, consultas, protocolos o aliases ajenos al batch.
+
+## 14. Piloto 20 pacientes
+
+No autorizado todavia.
+
+Plan cuando se autorice:
+
+- 5 pacientes solo demografia.
+- 5 pacientes con formularios `eye_mag`.
+- 5 pacientes con procedimiento/protocolo.
+- 5 pacientes con senales de facturacion/afiliacion.
+
+Todos los ejemplos y fixtures deben ser sinteticos o anonimizados; cero PII.

--- a/docs/openemr-medforge-migration/contracts/patient-v1.schema.json
+++ b/docs/openemr-medforge-migration/contracts/patient-v1.schema.json
@@ -13,6 +13,8 @@
     "demographics",
     "contacts",
     "clinical_aliases",
+    "identity_resolution",
+    "batch",
     "audit"
   ],
   "properties": {
@@ -48,13 +50,13 @@
         "organization_slug": {
           "type": "string",
           "minLength": 1,
-          "examples": ["altavision"]
+          "examples": ["alta-vision"]
         },
         "instance_slug": {
           "type": "string",
           "minLength": 1,
-          "examples": ["alta-vision-production"],
-          "description": "Must match a real Control Center instance before any write is allowed."
+          "examples": ["altavision-production"],
+          "description": "MedForge/Control Center instance slug. Must match a real Control Center instance before any write is allowed. Not persisted in core_patients."
         },
         "environment": {
           "type": "string",
@@ -74,15 +76,29 @@
     "source": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["system", "instance_slug", "environment"],
+      "required": ["system", "source_system", "source_instance", "medforge_instance_slug", "environment"],
       "properties": {
         "system": {
           "const": "openemr-altavision"
         },
+        "source_system": {
+          "const": "openemr"
+        },
+        "source_instance": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["altavision-openemr-production"]
+        },
+        "medforge_instance_slug": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["altavision-production"]
+        },
         "instance_slug": {
           "type": "string",
           "minLength": 1,
-          "examples": ["alta-vision-production"]
+          "deprecated": true,
+          "description": "Deprecated ambiguous field. Use medforge_instance_slug and source_instance."
         },
         "environment": {
           "type": "string",
@@ -113,11 +129,11 @@
         },
         "legacy_hc_number": {
           "type": ["string", "null"],
-          "description": "MedForge legacy hc_number or cedula-style identifier when present. External alias only."
+          "description": "Legacy hc_number when present in a source. External alias only. Not present in verified Alta Vision patient_data."
         },
         "national_identifier_hash": {
           "type": ["string", "null"],
-          "description": "Optional salted hash for pilot dedupe. Never store raw cedula in pilot artifacts."
+          "description": "Optional salted hash for pilot dedupe. Never store raw cedula in pilot artifacts. Cedula is a strong signal only when normalized and verified; it is not UNIQUE on core_patients."
         }
       }
     },
@@ -179,7 +195,7 @@
           },
           "external_type": {
             "type": "string",
-            "pattern": "^(openemr_pid|openemr_pubpid|openemr_patient_data_id|hc_number)$",
+            "pattern": "^(openemr_pid|openemr_pubpid|openemr_patient_data_id|hc_number|cedula_hash)$",
             "description": "Namespaced external type. Avoid generic values such as pid or id."
           },
           "external_id": {
@@ -187,8 +203,57 @@
             "description": "Deprecated compatibility alias for external_value. Do not use in new payloads."
           },
           "external_value": {"type": "string"},
+          "aliasable_type": {
+            "type": "string",
+            "const": "Patient",
+            "description": "Logical aliasable type for Patient V1. Implementation must map to the MedForge Patient model class and filter aliases by aliasable_type."
+          },
           "confidence": {"type": "string", "enum": ["exact", "inferred", "requires_review"]}
         }
+      }
+    },
+    "identity_resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strategy",
+        "manual_review_status",
+        "cedula_policy",
+        "idempotency_key"
+      ],
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "const": "provider_alias_resolution"
+        },
+        "manual_review_status": {
+          "type": "string",
+          "enum": ["not_required", "required", "approved", "rejected"]
+        },
+        "review_reasons": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "cedula_policy": {
+          "type": "string",
+          "enum": ["not_available", "strong_signal_verified", "ambiguous_manual_review", "ignored_invalid"]
+        },
+        "idempotency_key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable key built from source_instance plus deterministic source aliases/fingerprint."
+        }
+      }
+    },
+    "batch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["batch_id", "mode", "source_fingerprint"],
+      "properties": {
+        "batch_id": {"type": "string", "minLength": 1},
+        "mode": {"type": "string", "enum": ["dry_run", "staging_write", "production_write"]},
+        "source_fingerprint": {"type": "string", "minLength": 1},
+        "created_at": {"type": "string", "format": "date-time"}
       }
     },
     "legacy_links": {
@@ -208,11 +273,19 @@
       "properties": {
         "record_status": {
           "type": "string",
-          "enum": ["candidate", "accepted_for_pilot", "merged_into_existing", "rejected", "requires_review"]
+          "enum": ["candidate", "accepted_for_pilot", "matched_existing", "merged_into_existing", "manual_review_required", "rejected", "requires_review", "unchanged"]
         },
         "review_required": {"type": "boolean"},
         "review_reasons": {"type": "array", "items": {"type": "string"}},
-        "source_fingerprint": {"type": ["string", "null"]}
+        "source_fingerprint": {"type": ["string", "null"]},
+        "rollback_strategy": {
+          "type": "string",
+          "enum": ["discard_dry_run", "delete_batch_aliases_only", "delete_batch_records_if_unlinked", "manual_reconciliation_required"]
+        },
+        "reconciliation_status": {
+          "type": "string",
+          "enum": ["not_started", "idempotent_rerun_ok", "differences_detected", "manual_review_required"]
+        }
       }
     }
   }

--- a/docs/openemr-medforge-migration/contracts/patient-v1.schema.json
+++ b/docs/openemr-medforge-migration/contracts/patient-v1.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/jl1dvg/altavision52/docs/openemr-medforge-migration/contracts/patient-v1.schema.json",
+  "title": "AltaVision OpenEMR to MedForge Patient Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "contract_status",
+    "governance",
+    "source",
+    "identity",
+    "demographics",
+    "contacts",
+    "clinical_aliases",
+    "audit"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "patient-v1"
+    },
+    "contract_status": {
+      "type": "string",
+      "enum": ["Draft", "Accepted", "Deprecated"],
+      "default": "Draft"
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "organization_id",
+        "instance_id",
+        "organization_slug",
+        "instance_slug",
+        "environment",
+        "source_system",
+        "source_instance"
+      ],
+      "properties": {
+        "organization_id": {
+          "type": ["integer", "null"],
+          "description": "MedForge control_center_organizations.id when known. Null allowed only before Control Center registration."
+        },
+        "instance_id": {
+          "type": ["integer", "null"],
+          "description": "MedForge control_center_instances.id when known. Null allowed only before Control Center registration."
+        },
+        "organization_slug": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["altavision"]
+        },
+        "instance_slug": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["alta-vision-production"],
+          "description": "Must match a real Control Center instance before any write is allowed."
+        },
+        "environment": {
+          "type": "string",
+          "enum": ["production", "staging"]
+        },
+        "source_system": {
+          "type": "string",
+          "const": "openemr"
+        },
+        "source_instance": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["altavision-openemr-production"]
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "instance_slug", "environment"],
+      "properties": {
+        "system": {
+          "const": "openemr-altavision"
+        },
+        "instance_slug": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["alta-vision-production"]
+        },
+        "environment": {
+          "type": "string",
+          "enum": ["production", "staging"]
+        },
+        "extracted_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_patient_pid"],
+      "properties": {
+        "source_patient_pid": {
+          "type": "string",
+          "description": "OpenEMR patient_data.pid. External alias only."
+        },
+        "source_patient_id": {
+          "type": ["string", "null"],
+          "description": "OpenEMR patient_data.id if available. External alias only."
+        },
+        "source_pubpid": {
+          "type": ["string", "null"],
+          "description": "OpenEMR patient_data.pubpid. External alias only."
+        },
+        "legacy_hc_number": {
+          "type": ["string", "null"],
+          "description": "MedForge legacy hc_number or cedula-style identifier when present. External alias only."
+        },
+        "national_identifier_hash": {
+          "type": ["string", "null"],
+          "description": "Optional salted hash for pilot dedupe. Never store raw cedula in pilot artifacts."
+        }
+      }
+    },
+    "demographics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["full_name"],
+      "properties": {
+        "title": {"type": ["string", "null"]},
+        "first_name": {"type": ["string", "null"]},
+        "middle_name": {"type": ["string", "null"]},
+        "last_name": {"type": ["string", "null"]},
+        "second_last_name": {"type": ["string", "null"]},
+        "full_name": {"type": "string", "minLength": 1},
+        "birth_date": {"type": ["string", "null"], "format": "date"},
+        "sex": {"type": ["string", "null"]},
+        "occupation": {"type": ["string", "null"]},
+        "language": {"type": ["string", "null"]}
+      }
+    },
+    "contacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "phone_home": {"type": ["string", "null"]},
+        "phone_work": {"type": ["string", "null"]},
+        "phone_cell": {"type": ["string", "null"]},
+        "email": {"type": ["string", "null"]},
+        "street": {"type": ["string", "null"]},
+        "city": {"type": ["string", "null"]},
+        "state": {"type": ["string", "null"]},
+        "country_code": {"type": ["string", "null"]},
+        "postal_code": {"type": ["string", "null"]}
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$comment": "Coverage fields are accepted as source context only. Billing/coverage persistence is out of scope for patient-v1 and belongs to a future billing-v1 contract.",
+        "financial": {"type": ["string", "null"]},
+        "pricelevel": {"type": ["string", "null"]},
+        "affiliation": {"type": ["string", "null"]},
+        "billing_note_present": {"type": "boolean"}
+      }
+    },
+    "clinical_aliases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_system", "source_instance", "external_type", "external_value"],
+        "properties": {
+          "source_system": {"type": "string"},
+          "source_instance": {"type": "string"},
+          "provider": {
+            "type": "string",
+            "description": "Compatibility field for existing core_external_aliases.provider. Do not use as a separate patient identity subsystem."
+          },
+          "external_type": {
+            "type": "string",
+            "pattern": "^(openemr_pid|openemr_pubpid|openemr_patient_data_id|hc_number)$",
+            "description": "Namespaced external type. Avoid generic values such as pid or id."
+          },
+          "external_id": {
+            "type": "string",
+            "description": "Deprecated compatibility alias for external_value. Do not use in new payloads."
+          },
+          "external_value": {"type": "string"},
+          "confidence": {"type": "string", "enum": ["exact", "inferred", "requires_review"]}
+        }
+      }
+    },
+    "legacy_links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "form_ids": {"type": "array", "items": {"type": "string"}},
+        "consulta_data_keys": {"type": "array", "items": {"type": "string"}},
+        "procedimiento_proyectado_keys": {"type": "array", "items": {"type": "string"}},
+        "protocolo_data_keys": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_status", "review_required"],
+      "properties": {
+        "record_status": {
+          "type": "string",
+          "enum": ["candidate", "accepted_for_pilot", "merged_into_existing", "rejected", "requires_review"]
+        },
+        "review_required": {"type": "boolean"},
+        "review_reasons": {"type": "array", "items": {"type": "string"}},
+        "source_fingerprint": {"type": ["string", "null"]}
+      }
+    }
+  }
+}

--- a/docs/openemr-medforge-migration/contracts/patient-v1.schema.json
+++ b/docs/openemr-medforge-migration/contracts/patient-v1.schema.json
@@ -113,27 +113,32 @@
     "identity": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["source_patient_pid"],
+      "required": ["source_patient_pid", "pubpid_status"],
       "properties": {
         "source_patient_pid": {
           "type": "string",
-          "description": "OpenEMR patient_data.pid. External alias only."
+          "description": "OpenEMR patient_data.pid. Mandatory deterministic technical alias from the source; later associated to core_patients.id."
         },
         "source_patient_id": {
           "type": ["string", "null"],
-          "description": "OpenEMR patient_data.id if available. External alias only."
+          "description": "OpenEMR patient_data.id if available. Technical legacy table identifier, not a universal patient identity."
         },
         "source_pubpid": {
           "type": ["string", "null"],
-          "description": "OpenEMR patient_data.pubpid. External alias only."
+          "description": "OpenEMR patient_data.pubpid. Functional equivalent of MedForge patient_data.hc_number; represents cedula or patient identification number."
         },
-        "legacy_hc_number": {
+        "target_hc_number": {
           "type": ["string", "null"],
-          "description": "Legacy hc_number when present in a source. External alias only. Not present in verified Alta Vision patient_data."
+          "description": "MedForge patient_data.hc_number derived from source_pubpid only when source_pubpid is valid. Null when pubpid is empty, invalid, or duplicated."
+        },
+        "pubpid_status": {
+          "type": "string",
+          "enum": ["valid", "empty", "duplicate", "invalid"],
+          "description": "valid maps to target_hc_number; empty requires identification policy; duplicate requires manual review; invalid is rejected or reviewed by policy."
         },
         "national_identifier_hash": {
           "type": ["string", "null"],
-          "description": "Optional salted hash for pilot dedupe. Never store raw cedula in pilot artifacts. Cedula is a strong signal only when normalized and verified; it is not UNIQUE on core_patients."
+          "description": "Optional salted hash of the same functional identifier represented by source_pubpid/target_hc_number. Never store raw cedula in pilot artifacts. Not UNIQUE on core_patients."
         }
       }
     },
@@ -195,8 +200,8 @@
           },
           "external_type": {
             "type": "string",
-            "pattern": "^(openemr_pid|openemr_pubpid|openemr_patient_data_id|hc_number|cedula_hash)$",
-            "description": "Namespaced external type. Avoid generic values such as pid or id."
+            "pattern": "^(openemr_pid|openemr_pubpid|openemr_patient_data_id|hc_number)$",
+            "description": "Namespaced external type. openemr_pubpid and hc_number are the same functional patient identification concept across systems; avoid generic values such as pid or id."
           },
           "external_id": {
             "type": "string",
@@ -218,7 +223,7 @@
       "required": [
         "strategy",
         "manual_review_status",
-        "cedula_policy",
+        "identification_policy",
         "idempotency_key"
       ],
       "properties": {
@@ -234,9 +239,9 @@
           "type": "array",
           "items": {"type": "string"}
         },
-        "cedula_policy": {
+        "identification_policy": {
           "type": "string",
-          "enum": ["not_available", "strong_signal_verified", "ambiguous_manual_review", "ignored_invalid"]
+          "enum": ["pubpid_valid_maps_to_hc_number", "pubpid_empty_identification_policy_pending", "pubpid_duplicate_manual_review", "ignored_invalid"]
         },
         "idempotency_key": {
           "type": "string",

--- a/docs/openemr-medforge-migration/handoffs/medforge-core-alias-uniqueness-p0.md
+++ b/docs/openemr-medforge-migration/handoffs/medforge-core-alias-uniqueness-p0.md
@@ -21,7 +21,9 @@ No incluir `aliasable_id` en la restriccion unique.
 - Alta Vision usara instancia clinica y DB independiente.
 - `core_patients` no tendra `organization_id` ni `instance_id`.
 - `core_patients.id` sera identidad clinica soberana.
-- `pid`, `pubpid`, `hc_number`, `form_id` y otros identificadores externos seran aliases.
+- `patient_data.pid` de OpenEMR sera alias tecnico obligatorio asociado a `core_patients.id`.
+- `patient_data.pubpid` de OpenEMR equivale funcionalmente a `patient_data.hc_number` de MedForge; ambos representan cedula o numero de identificacion.
+- `form_id` y otros identificadores de formularios seran aliases/llaves legacy del dominio correspondiente, no identidad primaria de paciente.
 - Patient V1 debe reutilizar arquitectura Provider, `ProviderIdentityResolver`, `AliasResolution` y `core_external_aliases`.
 - No se autoriza identidad paralela para pacientes.
 

--- a/docs/openemr-medforge-migration/handoffs/medforge-core-alias-uniqueness-p0.md
+++ b/docs/openemr-medforge-migration/handoffs/medforge-core-alias-uniqueness-p0.md
@@ -1,0 +1,112 @@
+# Handoff MedForge Core - P0 core_external_aliases
+
+Estado: especificacion, no codigo.
+Clasificacion: deuda P0 del Core.
+Separacion obligatoria: no mezclar con importador OpenEMR ni con Patient V1.
+
+## Objetivo
+
+Corregir la restriccion de unicidad de `core_external_aliases` para que refleje su naturaleza polimorfica.
+
+Nueva unicidad minima:
+
+```php
+['aliasable_type', 'instance_slug', 'provider', 'external_type', 'external_id']
+```
+
+No incluir `aliasable_id` en la restriccion unique.
+
+## Contexto aprobado
+
+- Alta Vision usara instancia clinica y DB independiente.
+- `core_patients` no tendra `organization_id` ni `instance_id`.
+- `core_patients.id` sera identidad clinica soberana.
+- `pid`, `pubpid`, `hc_number`, `form_id` y otros identificadores externos seran aliases.
+- Patient V1 debe reutilizar arquitectura Provider, `ProviderIdentityResolver`, `AliasResolution` y `core_external_aliases`.
+- No se autoriza identidad paralela para pacientes.
+
+## Archivos probables
+
+- `laravel-app/database/migrations/YYYY_MM_DD_HHMMSS_fix_core_external_aliases_polymorphic_uniqueness.php`.
+- `laravel-app/app/Modules/Core/Models/ExternalAlias.php`.
+- `laravel-app/app/Modules/Core/Http/Controllers/SedesUiController.php`.
+- `laravel-app/app/Modules/Core/Services/ProviderIdentityResolver.php`.
+- `laravel-app/app/Modules/Core/Models/AliasResolution.php`.
+- `laravel-app/tests/Feature/Core/CoreExternalAliasUniquenessTest.php`.
+- `laravel-app/tests/Feature/Core/ProviderIdentityResolverTest.php`.
+
+## Auditoria previa sin PII
+
+Antes de tocar indices, detectar colisiones que bloquearian el nuevo unique:
+
+- mismo `aliasable_type`;
+- mismo `instance_slug`;
+- mismo `provider`;
+- mismo `external_type`;
+- mismo `external_id`;
+- mas de un `aliasable_id`.
+
+Reporte permitido:
+
+- conteo total de aliases auditados;
+- conteo de colisiones bloqueantes;
+- `aliasable_type`;
+- `instance_slug`;
+- `provider`;
+- `external_type`;
+- hash SHA-256 de `external_id`, no valor crudo;
+- cantidad de `aliasable_id` distintos;
+- cantidad de filas.
+
+No permitido:
+
+- imprimir `external_id` crudo;
+- imprimir nombres, cedulas, telefonos, correos o datos clinicos;
+- eliminar, fusionar o reasignar aliases automaticamente.
+
+Comando sugerido:
+
+```bash
+php artisan core:external-aliases:audit-uniqueness --no-pii --format=json
+```
+
+## Migracion Laravel reversible
+
+`up()`:
+
+- Auditar colisiones bloqueantes.
+- Si existen colisiones bloqueantes, lanzar excepcion antes de modificar indices.
+- Dropear el unique anterior sobre `instance_slug`, `provider`, `external_type`, `external_id` si existe.
+- Crear `core_external_aliases_polymorphic_instance_unique` sobre `aliasable_type`, `instance_slug`, `provider`, `external_type`, `external_id`.
+
+`down()`:
+
+- Dropear `core_external_aliases_polymorphic_instance_unique`.
+- Auditar si existen valores compartidos entre tipos que impedirian restaurar el unique anterior.
+- Si existen, detener rollback con excepcion.
+- Restaurar el unique anterior solo si es representable.
+
+## Comportamiento esperado
+
+- Patient y Sede pueden compartir el mismo `instance_slug`, `provider`, `external_type`, `external_id`.
+- Dos Patient no pueden compartir el mismo alias externo dentro de la misma instancia.
+- `ProviderIdentityResolver` conserva match deterministico filtrado por `aliasable_type`.
+- `AliasResolution` sigue usando la misma tabla y no cambia de contrato.
+
+## Pruebas obligatorias
+
+- Crear Patient y Sede con el mismo valor externo: debe pasar.
+- Crear dos Patient con el mismo valor externo: debe fallar por unique.
+- Auditoria reporta hashes y conteos sin PII.
+- Migracion se detiene si detecta colisiones bloqueantes.
+- `ProviderIdentityResolverTest` sigue pasando.
+- Prueba de `AliasResolution` confirma compatibilidad.
+
+## Criterios de aceptacion
+
+- PR independiente contra MedForge, clasificado P0 Core.
+- Migracion reversible.
+- Sin importador OpenEMR.
+- Sin fusion automatica.
+- Sin PII en logs/reportes/tests.
+- Tests verdes para Patient, Sede, ProviderIdentityResolver y AliasResolution.

--- a/docs/openemr-medforge-migration/orchestration/roadmap-next-steps-2026-07-31.md
+++ b/docs/openemr-medforge-migration/orchestration/roadmap-next-steps-2026-07-31.md
@@ -35,8 +35,8 @@ Aunque `pubpid` y `hc_number` tienen la misma semantica funcional, OpenEMR prese
 
 ### Alta Vision / OpenEMR
 
-- PR base limpio: #56, Patient V1 Draft contra `master`.
-- PR incremental de readiness: #57, limpio y acotado a documentacion.
+- PR superseded: #56, Patient V1 Draft inicial contra `master`.
+- PR canonico activo: #57, contiene el contenido de #56 mas readiness, handoff y roadmap; debe ser el unico PR activo hacia `master`.
 - `patient_data`: 22.653 pacientes.
 - `pid`: completo y unico.
 - `pubpid`: equivalente a cedula/identificacion, con vacios y duplicados que requieren politica de conflicto.
@@ -64,10 +64,10 @@ Actualizar `patient-v1.md` y `patient-v1.schema.json` para que quede explicito:
 - `patient_data.id` como ID tecnico legacy.
 - Manejo de `pubpid` vacio o duplicado sin merge automatico.
 
-Orden documental recomendado:
+Orden documental aplicado:
 
-1. Revisar y mergear PR #56.
-2. Retargetear PR #57 a `master` despues del merge de #56, o mergearlo como PR apilado inmediatamente despues de #56.
+1. Mantener PR #57 como canonico hacia `master`.
+2. Marcar y cerrar PR #56 como superseded sin merge.
 3. Mantener Patient V1 como Draft hasta completar los bloqueantes del destino.
 
 ### Paso 2 — Limpiar la revision MedForge

--- a/docs/openemr-medforge-migration/orchestration/roadmap-next-steps-2026-07-31.md
+++ b/docs/openemr-medforge-migration/orchestration/roadmap-next-steps-2026-07-31.md
@@ -1,0 +1,167 @@
+# Orquestacion y siguientes pasos — OpenEMR Alta Vision a MedForge
+
+Fecha local Ecuador: 2026-07-31
+Estado general: Patient V1 permanece Draft. No se autoriza todavia migracion masiva ni escritura en produccion.
+
+## Objetivo del programa
+
+Migrar Alta Vision por etapas desde OpenEMR hacia MedForge y, al mismo tiempo, convertir las mejores logicas, formularios y procesos desarrollados en OpenEMR en capacidades nativas de la aplicacion base de MedForge.
+
+El objetivo no es copiar OpenEMR ni crear una dependencia permanente. Cada dominio debe dejar dos resultados:
+
+1. Datos de Alta Vision migrados y reconciliados.
+2. Una capacidad reusable incorporada a MedForge Core, al modulo de Oftalmologia o a configuracion por instancia.
+
+## Gobierno
+
+- Jorge: decisiones funcionales, clinicas, tratamiento de datos reales y cambios irreversibles.
+- ChatGPT: orquestacion, orden de fases, revision cruzada, actualizacion de Notion y seguimiento de PR/Markdown.
+- Codex: auditoria y modificaciones en `altavision52` / OpenEMR, contratos, extractores y reconciliacion del origen.
+- Claude Code: auditoria y modificaciones en `MedForge`, arquitectura Laravel, migraciones, servicios y pruebas del destino.
+
+## Equivalencias confirmadas por Jorge
+
+| OpenEMR Alta Vision | MedForge | Regla |
+|---|---|---|
+| `patient_data.pid` | alias externo OpenEMR asociado a `core_patients.id` | ID tecnico interno del origen; no se reutiliza como PK de MedForge |
+| `patient_data.pubpid` | `patient_data.hc_number` | Ambos representan cedula o numero de identificacion |
+| `patient_data.lname2` | `patient_data.lname2` | Mapeo directo; existe en ambos sistemas |
+| identidad interna MedForge | `core_patients.id` | Identidad soberana y nueva del Core |
+| fila demografica legacy | `patient_data.id` | Se conserva como ID tecnico de la tabla legacy, no como identidad universal |
+
+Aunque `pubpid` y `hc_number` tienen la misma semantica funcional, OpenEMR presenta valores vacios y duplicados. Estos casos deben reportarse y resolverse sin fusion automatica.
+
+## Estado verificado
+
+### Alta Vision / OpenEMR
+
+- PR base limpio: #56, Patient V1 Draft contra `master`.
+- PR incremental de readiness: #57, limpio y acotado a documentacion.
+- `patient_data`: 22.653 pacientes.
+- `pid`: completo y unico.
+- `pubpid`: equivalente a cedula/identificacion, con vacios y duplicados que requieren politica de conflicto.
+- `lname2`: personalizacion real y compatible con MedForge.
+- No se extrajo PII ni se realizaron escrituras.
+
+### MedForge
+
+- `core_patients` y `core_external_aliases` ya existen.
+- Debe corregirse en un PR P0 independiente la unicidad polimorfica de `core_external_aliases`.
+- PR #1065 es solo una revision documental, pero su diff actual esta contaminado: base `main`, 126 commits y 170 archivos. No debe mergearse en ese estado; Claude debe reconstruir el informe en una rama limpia desde `origin/staging`.
+
+## Siguientes pasos inmediatos
+
+### Paso 1 — Corregir y cerrar el contrato Patient V1
+
+Responsable: Codex en `altavision52`.
+
+Actualizar `patient-v1.md` y `patient-v1.schema.json` para que quede explicito:
+
+- `pubpid -> patient_data.hc_number` como cedula/identificacion.
+- `lname2 -> patient_data.lname2` por mapeo directo.
+- `pid -> core_external_aliases` como alias tecnico de OpenEMR.
+- `core_patients.id` como identidad interna soberana.
+- `patient_data.id` como ID tecnico legacy.
+- Manejo de `pubpid` vacio o duplicado sin merge automatico.
+
+Orden documental recomendado:
+
+1. Revisar y mergear PR #56.
+2. Retargetear PR #57 a `master` despues del merge de #56, o mergearlo como PR apilado inmediatamente despues de #56.
+3. Mantener Patient V1 como Draft hasta completar los bloqueantes del destino.
+
+### Paso 2 — Limpiar la revision MedForge
+
+Responsable: Claude Code en `MedForge`.
+
+- No continuar sobre PR #1065 tal como esta.
+- Crear una rama limpia desde `origin/staging`.
+- Llevar unicamente el documento `docs/architecture/openemr-medforge-patient-v1-review-2026-07-31.md` y las correcciones documentales necesarias.
+- Abrir un PR documental limpio hacia `staging`.
+- Cerrar o marcar #1065 como superseded despues de crear el reemplazo.
+
+### Paso 3 — Corregir aliases P0 en MedForge
+
+Responsable: Claude Code en un PR separado hacia `staging`.
+
+- Auditar colisiones agregadas sin PII.
+- Cambiar la unicidad a `aliasable_type + instance_slug + provider + external_type + external_id`.
+- No incluir `aliasable_id` en el indice unico.
+- Incluir migracion reversible y pruebas para Patient/Sede.
+- No mezclar este PR con el importador OpenEMR.
+
+### Paso 4 — Preparar Alta Vision en Control Center
+
+Responsable: Claude Code; ejecucion real requiere autorizacion de Jorge.
+
+Preparar:
+
+- organizacion `alta-vision`;
+- instancia `altavision-staging`;
+- instancia `altavision-production`;
+- base clinica independiente por instancia, aunque pueda compartir VPS.
+
+### Paso 5 — Fixtures sinteticos y piloto tecnico
+
+Responsables: Codex + Claude Code, coordinados por ChatGPT.
+
+- Crear fixtures completamente sinteticos.
+- Incluir casos normales, `pubpid` vacio, `pubpid` duplicado, `lname2`, telefono/email invalidos y paciente ya existente.
+- Probar validacion del contrato, idempotencia, cola de revision y rollback.
+- No usar pacientes reales en esta etapa.
+
+### Paso 6 — Pasar Patient V1 de Draft a Accepted
+
+Condiciones:
+
+- mapping corregido;
+- PR P0 de aliases aprobado;
+- instancias preparadas en Control Center;
+- fixtures sinteticos validados;
+- revision final de Jorge.
+
+### Paso 7 — Migracion de Pacientes por lotes
+
+Solo despues de Accepted:
+
+1. dry-run sin escritura;
+2. piloto autorizado de 20 registros controlados;
+3. reconciliacion origen/destino;
+4. lote de 100;
+5. lotes incrementales con rollback y metricas;
+6. carga delta final cuando MedForge asuma la operacion.
+
+## Patron para enriquecer MedForge en cada etapa
+
+Cada dominio de OpenEMR se clasificara antes de implementarse:
+
+- **MedForge Core:** pacientes, profesionales, sedes, citas, encuentros, diagnosticos, documentos, recetas, auditoria y consentimientos.
+- **MedForge Ophthalmology:** agudeza visual, refraccion, tonometria, biomicroscopia, fondo de ojo, lateralidad, planes y formularios oftalmologicos.
+- **Configuracion Alta Vision:** catalogos, plantillas, reglas o flujos exclusivos de la clinica.
+- **Retirar/no migrar:** codigo obsoleto, duplicado, inseguro o reemplazado por una solucion mejor.
+
+Ciclo obligatorio por dominio:
+
+1. Codex audita datos, codigo y uso real en OpenEMR.
+2. ChatGPT define alcance, clasificacion y orden.
+3. Claude audita el destino e implementa la capacidad base en MedForge.
+4. Se crean contratos y fixtures sinteticos.
+5. Se ejecuta piloto pequeno y reconciliacion.
+6. Se migra por lotes.
+7. La capacidad queda documentada como parte reusable de MedForge.
+
+## Orden de dominios posterior a Pacientes
+
+1. Profesionales, usuarios y sedes.
+2. Agenda y citas futuras.
+3. Encuentros/consultas e historia clinica longitudinal.
+4. Formularios oftalmologicos y logicas desarrolladas en OpenEMR.
+5. Diagnosticos, recetas y ordenes.
+6. Documentos, imagenes y consentimientos.
+7. Procedimientos, cirugias y protocolos.
+8. Facturacion y cartera.
+9. Sincronizacion incremental, corte y OpenEMR en solo lectura.
+
+## Regla de control
+
+Ninguna fase se considera terminada solo porque un script se ejecuto. Deben quedar verificadas la integridad de datos, la logica funcional, la trazabilidad, la idempotencia, el rollback y la incorporacion reusable en MedForge base.

--- a/docs/openemr-medforge-migration/readiness/phase-1-3-patient-readiness.md
+++ b/docs/openemr-medforge-migration/readiness/phase-1-3-patient-readiness.md
@@ -1,0 +1,132 @@
+# Fase 1.3 - readiness Patient V1
+
+Estado: Draft.
+Fecha local Ecuador: 2026-07-30.
+Fecha UTC de ejecucion remota: 2026-07-31.
+
+## Resumen
+
+Patient V1 no puede pasar a Accepted todavia.
+
+La verificacion estructural de OpenEMR/Alta Vision avanzo: se accedio al VPS por SSH, se identifico el vhost activo y se ejecuto una auditoria agregada sobre la base configurada por OpenEMR sin extraer PII y sin escribir datos.
+
+Bloqueantes vigentes:
+
+- PR P0 independiente de MedForge para corregir la unicidad polimorfica de `core_external_aliases`.
+- Preparacion formal de organizacion e instancias Alta Vision en Control Center.
+- Fixtures sinteticos del piloto.
+- Revision final de Jorge para pasar `patient-v1` de Draft a Accepted.
+
+## Fuentes verificadas
+
+- SSH operativo: alias `altavision-vps`.
+- Alias no operativo en este entorno: `altavision_vps`.
+- Vhost Alta Vision: `app.alta-vision.com`.
+- Document root: `/var/www/html/altavision`.
+- Config OpenEMR: `/var/www/html/altavision/sites/default/sqlconf.php`.
+- Esquema activo: documentado por hash `defe7bcf4b072b0b`.
+- Conexion DB: `ok`.
+- Modo: lectura/metadatos/agregados solamente.
+- PII publicada: ninguna.
+
+## Tablas reales
+
+Presentes:
+
+- `patient_data`.
+- `history_data`.
+- `insurance_data`.
+- `form_encounter`.
+- `forms`.
+- `documents`.
+- `categories_to_documents`.
+- `openemr_postcalendar_events`.
+- `billing`.
+- `transactions`.
+- `lists`.
+- `pnotes`.
+
+No presentes en el esquema activo:
+
+- `appointments`.
+- `consulta_data`.
+- `procedimiento_proyectado`.
+- `protocolo_data`.
+
+## Estructura patient_data
+
+Indices verificados:
+
+- `pid`: unique sobre `pid`.
+- `id`: indice no unique sobre `id`.
+
+Columnas relevantes:
+
+- `pid`, `id`, `pubpid`.
+- `fname`, `mname`, `lname`, `lname2`.
+- `DOB`, `sex`.
+- `ss`, `email`, `phone_home`, `phone_biz`, `phone_cell`, `phone_contact`.
+- `status`, `deceased_date`, `deceased_reason`.
+- `genericname1`, `genericval1`, `genericname2`, `genericval2`.
+- `hipaa_allowwhatsapp`.
+
+Hallazgos estructurales:
+
+- `hc_number` no existe en `patient_data`.
+- `lname2` existe en la base real y no aparece en el `CREATE TABLE patient_data` base de `sql/database.sql`; se clasifica como personalizacion real o drift aplicado.
+- `hipaa_allowwhatsapp` existe y esta versionado en `sql/6_0_0-to-whatsapp_allow-idempotent.sql`.
+
+## Metricas agregadas
+
+Pacientes:
+
+- Total `patient_data`: 22.653.
+- `pid`: 22.653 distintos, 0 vacios, 0 duplicados.
+- `id`: 22.653 distintos, 0 vacios, 0 duplicados.
+- `pubpid`: 5 vacios, 22.618 distintos no vacios, 30 grupos duplicados, 60 filas en grupos duplicados.
+- `ss`: 22.653 vacios.
+- `hc_number`: no existe.
+
+Calidad demografica/contacto:
+
+- `DOB`: 32 vacios, 6 futuros, 10 anteriores a 1900, rango agregado de anios 149-2067.
+- `sex`: 264 vacios, 2 valores distintos no vacios.
+- `email`: 3.266 vacios, 10.149 con forma invalida, 593 grupos duplicados.
+- `phone_cell`: 1.694 vacios, 1.167 grupos duplicados.
+- `deceased_date`: 0 con valor.
+- `status`: 5 valores distintos no vacios.
+
+Relaciones:
+
+- `form_encounter`: 84.971 filas, 20.936 pacientes enlazados.
+- `forms`: 233.128 filas, 20.936 pacientes enlazados.
+- `documents`: 14.997 filas.
+- `openemr_postcalendar_events`: 95.974 filas, 21.242 pacientes enlazados.
+- `billing`: 906.240 filas, 10.525 pacientes enlazados.
+- `transactions`: 5.469 filas, 3.131 pacientes enlazados.
+- `lists`: 22.331 filas, 12.038 pacientes enlazados.
+- `pnotes`: 19 filas, 11 pacientes enlazados.
+
+## Implicaciones para Patient V1
+
+- `openemr_pid` puede ser alias determinista principal.
+- `openemr_patient_data_id` puede ser alias determinista secundario.
+- `openemr_pubpid` no puede usarse como llave unica por duplicados y vacios.
+- Cedula no puede validarse desde `ss` en esta fuente porque esta vacia en todos los pacientes verificados.
+- `hc_number` no puede mapearse desde `patient_data` porque la columna no existe.
+- Datos de contacto y fechas requieren reglas de normalizacion y revision, no deben bloquear identidad soberana salvo criterios clinicos aprobados.
+- Billing existe con alto volumen, pero sigue fuera de `patient-v1`; se reserva para `billing-v1`.
+
+## Readiness
+
+| Criterio | Estado |
+|---|---|
+| Esquema real OpenEMR verificado sin PII | Parcialmente cumplido |
+| Metricas agregadas de calidad documentadas | Cumplido para Pacientes |
+| Personalizaciones reales identificadas | Parcialmente cumplido |
+| PR P0 aliases MedForge | Pendiente |
+| Control Center Alta Vision | Pendiente |
+| Fixtures sinteticos piloto | Pendiente |
+| Patient V1 Accepted | No |
+
+Decision de readiness: mantener `patient-v1` en Draft.

--- a/docs/openemr-medforge-migration/readiness/phase-1-3-patient-readiness.md
+++ b/docs/openemr-medforge-migration/readiness/phase-1-3-patient-readiness.md
@@ -72,7 +72,7 @@ Columnas relevantes:
 
 Hallazgos estructurales:
 
-- `hc_number` no existe en `patient_data`.
+- `hc_number` no existe como columna en OpenEMR `patient_data`; el equivalente funcional en MedForge es `patient_data.hc_number`, alimentado desde OpenEMR `patient_data.pubpid` cuando el valor sea valido.
 - `lname2` existe en la base real y no aparece en el `CREATE TABLE patient_data` base de `sql/database.sql`; se clasifica como personalizacion real o drift aplicado.
 - `hipaa_allowwhatsapp` existe y esta versionado en `sql/6_0_0-to-whatsapp_allow-idempotent.sql`.
 
@@ -83,9 +83,9 @@ Pacientes:
 - Total `patient_data`: 22.653.
 - `pid`: 22.653 distintos, 0 vacios, 0 duplicados.
 - `id`: 22.653 distintos, 0 vacios, 0 duplicados.
-- `pubpid`: 5 vacios, 22.618 distintos no vacios, 30 grupos duplicados, 60 filas en grupos duplicados.
+- `pubpid`: equivale funcionalmente a `hc_number`/cedula/numero de identificacion; 5 vacios, 22.618 distintos no vacios, 30 grupos duplicados, 60 filas en grupos duplicados.
 - `ss`: 22.653 vacios.
-- `hc_number`: no existe.
+- `hc_number`: no existe como columna OpenEMR; se deriva funcionalmente de `pubpid` hacia MedForge cuando sea valido.
 
 Calidad demografica/contacto:
 
@@ -111,9 +111,11 @@ Relaciones:
 
 - `openemr_pid` puede ser alias determinista principal.
 - `openemr_patient_data_id` puede ser alias determinista secundario.
-- `openemr_pubpid` no puede usarse como llave unica por duplicados y vacios.
-- Cedula no puede validarse desde `ss` en esta fuente porque esta vacia en todos los pacientes verificados.
-- `hc_number` no puede mapearse desde `patient_data` porque la columna no existe.
+- `openemr_pubpid` se mapea funcionalmente a `patient_data.hc_number` de MedForge cuando sea valido.
+- `pubpid` vacio deja al paciente pendiente de politica de identificacion.
+- `pubpid` duplicado es conflicto de identificacion y requiere revision manual.
+- Nunca se deben fusionar pacientes automaticamente por coincidencia de `pubpid`/`hc_number`/cedula.
+- Cedula no puede validarse desde `ss` en esta fuente porque esta vacia en todos los pacientes verificados; la fuente funcional confirmada es `pubpid`.
 - Datos de contacto y fechas requieren reglas de normalizacion y revision, no deben bloquear identidad soberana salvo criterios clinicos aprobados.
 - Billing existe con alto volumen, pero sigue fuera de `patient-v1`; se reserva para `billing-v1`.
 


### PR DESCRIPTION
## Estado canonico

Este PR es la referencia canonica activa para Patient V1 en `jl1dvg/altavision52` y apunta a `master`.

Supersede a #56 porque contiene todo su contenido mas readiness Fase 1.3, handoff P0 y roadmap de orquestacion. #56 queda cerrado sin merge.

## Equivalencias definitivas aprobadas por Jorge

- `patient_data.pid` de OpenEMR es identificador interno tecnico del paciente en OpenEMR.
- `pid` se conserva como alias externo obligatorio/deterministico de OpenEMR asociado posteriormente a `core_patients.id`.
- `patient_data.pubpid` de OpenEMR equivale funcionalmente a `patient_data.hc_number` de MedForge.
- `pubpid` y `hc_number` representan cedula o numero de identificacion del paciente.
- `patient_data.lname2` se mapea directamente a `patient_data.lname2` de MedForge.
- `core_patients.id` sera la identidad interna soberana del paciente en MedForge.
- `patient_data.id` de MedForge sigue siendo identificador tecnico de tabla legacy, no identidad universal.

## Reglas pubpid / hc_number / cedula

- Valor valido: mapear `patient_data.pubpid` de OpenEMR a `patient_data.hc_number` de MedForge.
- Valor vacio: paciente pendiente de politica de identificacion.
- Valor duplicado: conflicto que requiere revision manual.
- Nunca fusionar pacientes automaticamente por coincidencia de identificacion.

## Alcance

- Actualiza contrato `Patient V1` y JSON Schema.
- Actualiza mapping de pacientes, readiness y roadmap de orquestacion.
- Mantiene idempotencia, trazabilidad por lote, deteccion de conflictos, revision manual, rollback y reconciliacion.
- Mantiene `Patient V1` en estado `Draft`.

## No incluido

- No importador.
- No migracion de pacientes.
- No escrituras a base clinica.
- No PII.
- No cambios en MedForge.
- No fixtures del piloto todavia.

## Validacion

- `patient-v1.schema.json` validado con parser JSON estricto.
- Diff limitado a `docs/openemr-medforge-migration/`.
