### PR TITLE
Restore provider second last name support

### DIFF
--- a/interface/usergroup/addrbook_edit.php
+++ b/interface/usergroup/addrbook_edit.php
@@ -125,6 +125,7 @@ if ($_POST['form_save']) {
         $form_title = invalue('form_director_title');
         $form_fname = invalue('form_director_fname');
         $form_lname = invalue('form_director_lname');
+        $form_lname2 = invalue('form_director_lname2');
         $form_mname = invalue('form_director_mname');
         $form_suffix = invalue('form_director_suffix');
     } else {
@@ -132,6 +133,7 @@ if ($_POST['form_save']) {
         $form_title = invalue('form_title');
         $form_fname = invalue('form_fname');
         $form_lname = invalue('form_lname');
+        $form_lname2 = invalue('form_lname2');
         $form_mname = invalue('form_mname');
         $form_suffix = invalue('form_suffix');
     }
@@ -142,6 +144,7 @@ if ($_POST['form_save']) {
         "title = "        . $form_title                  . ", " .
         "fname = "        . $form_fname                  . ", " .
         "lname = "        . $form_lname                  . ", " .
+        "lname2 = "       . $form_lname2                 . ", " .
         "mname = "        . $form_mname                  . ", " .
         "suffix = "       . $form_suffix                 . ", " .
         "specialty = "    . invalue('form_specialty')    . ", " .
@@ -177,7 +180,7 @@ if ($_POST['form_save']) {
     } else {
         $userid = sqlInsert("INSERT INTO users ( " .
         "username, password, authorized, info, source, " .
-        "title, fname, lname, mname, suffix, " .
+        "title, fname, lname, lname2, mname, suffix, " .
         "federaltaxid, federaldrugid, upin, facility, see_auth, active, npi, taxonomy, cpoe, " .
         "specialty, organization, valedictory, assistant, billname, email, email_direct, url, " .
         "street, streetb, city, state, zip, " .
@@ -192,6 +195,7 @@ if ($_POST['form_save']) {
         $form_title                   . ", " .
         $form_fname                   . ", " .
         $form_lname                   . ", " .
+        $form_lname2                  . ", " .
         $form_mname                   . ", " .
         $form_suffix                  . ", " .
         invalue('form_federaltaxid')  . ", " .
@@ -296,6 +300,8 @@ if ($type) { // note this only happens when its new
 ?>
    <div style="display: inline-block"><b><?php echo xlt('Last'); ?>:</b><input type='text' size='10' name='form_lname' class='inputtext'
                                                                                maxlength='50' value='<?php echo attr($row['lname']); ?>'/></div>
+   <div style="display: inline-block"><b><?php echo xlt('Second Last'); ?>:</b><input type='text' size='10' name='form_lname2' class='inputtext'
+                                                                               maxlength='50' value='<?php echo attr($row['lname2']); ?>'/></div>
    <div style="display: inline-block"><b><?php echo xlt('First'); ?>:</b> <input type='text' size='10' name='form_fname' class='inputtext'
                                                                                  maxlength='50' value='<?php echo attr($row['fname']); ?>' />&nbsp;</div>
    <div style="display: inline-block"><b><?php echo xlt('Middle'); ?>:</b> <input type='text' size='4' name='form_mname' class='inputtext'
@@ -335,6 +341,8 @@ if ($type) { // note this only happens when its new
 ?>
    <b><?php echo xlt('Last'); ?>:</b><input type='text' size='10' name='form_director_lname' class='inputtext'
      maxlength='50' value='<?php echo attr($row['lname']); ?>'/>&nbsp;
+   <b><?php echo xlt('Second Last'); ?>:</b><input type='text' size='10' name='form_director_lname2' class='inputtext'
+     maxlength='50' value='<?php echo attr($row['lname2']); ?>'/>&nbsp;
    <b><?php echo xlt('First'); ?>:</b> <input type='text' size='10' name='form_director_fname' class='inputtext'
      maxlength='50' value='<?php echo attr($row['fname']); ?>' />&nbsp;
    <b><?php echo xlt('Middle'); ?>:</b> <input type='text' size='4' name='form_director_mname' class='inputtext'

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -141,7 +141,7 @@ function submitform() {
     for(i=0;i<f.length;i++){
       if(f[i].type=='text' && f[i].value)
       {
-        if(f[i].name == 'fname' || f[i].name == 'mname' || f[i].name == 'lname')
+        if(f[i].name == 'fname' || f[i].name == 'mname' || f[i].name == 'lname' || f[i].name == 'lname2')
         {
           alertMsg += checkLength(f[i].name,f[i].value,35);
           alertMsg += checkUsername(f[i].name,f[i].value);
@@ -328,6 +328,10 @@ if ($password_exp != "0000-00-00") {
 
 <TR>
 <td><span class=text><?php echo xlt('Last Name'); ?>: </span></td><td><input type=entry name=lname id=lname style="width:150px;"  class="form-control" value="<?php echo attr($iter["lname"]); ?>"><span class="mandatory"></span></td>
+<td><span class=text><?php echo xlt('Second Last Name'); ?>: </span></td><td><input type=entry name=lname2 style="width:150px;" class="form-control" value="<?php echo attr($iter["lname2"]); ?>"></td>
+</TR>
+
+<TR>
 <td><span class=text><?php echo xlt('Default Facility'); ?>: </span></td><td><select name=facility_id style="width:150px;" class="form-control">
 <?php
 $fres = $facilityService->getAllBillingLocations();

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -119,7 +119,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] =="user_admin") {
             sqlStatement("update users set taxonomy = ? where id= ? ", array($_POST["taxonomy"], $_POST["id"]));
         }
 
-        if (isset($_POST["lname"])) {
+        if ($_POST["lname"]) {
             sqlStatement("update users set lname=? where id= ? ", array($_POST["lname"], $_POST["id"]));
         }
 
@@ -131,7 +131,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] =="user_admin") {
             sqlStatement("update users set specialty=? where id= ? ", array($_POST["job"], $_POST["id"]));
         }
 
-        if (isset($_POST["mname"])) {
+        if ($_POST["mname"]) {
             sqlStatement("update users set mname=? where id= ? ", array($_POST["mname"], $_POST["id"]));
         }
 
@@ -155,7 +155,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] =="user_admin") {
             }
         }
 
-        if (isset($_POST["fname"])) {
+        if ($_POST["fname"]) {
             sqlStatement("update users set fname=? where id= ? ", array($_POST["fname"], $_POST["id"]));
         }
 
@@ -365,7 +365,7 @@ if (isset($_POST["mode"])) {
 
         $doit = 1;
         foreach ($result as $iter) {
-            if ($doit == 1 && $iter["name"] == (trim((isset($_POST['groupname']) ? $_POST['groupname'] : ''))) && $iter["user"] == (trim((isset($_POST['rumple']) ? $_POST['rumple'] : '')))) {
+            if ($doit == 1 && $iter{"name"} == (trim((isset($_POST['groupname']) ? $_POST['groupname'] : ''))) && $iter{"user"} == (trim((isset($_POST['rumple']) ? $_POST['rumple'] : '')))) {
                 $doit--;
             }
         }
@@ -400,7 +400,7 @@ if (isset($_GET["mode"])) {
     // reference users to make sure this user is not referenced!
 
     foreach($result as $iter) {
-      sqlStatement("delete from `groups` where user = '" . $iter["username"] . "'");
+      sqlStatement("delete from `groups` where user = '" . $iter{"username"} . "'");
     }
     sqlStatement("delete from users where id = '" . $_GET["id"] . "'");
   }
@@ -413,7 +413,7 @@ if (isset($_GET["mode"])) {
         }
 
         foreach ($result as $iter) {
-            $un = $iter["user"];
+            $un = $iter{"user"};
         }
 
         $res = sqlStatement("select name, user from `groups` where user = ? " .
@@ -533,10 +533,10 @@ function authorized_clicked() {
                         }
 
                         foreach ($result4 as $iter) {
-                            if ($iter["authorized"]) {
-                                $iter["authorized"] = xl('yes');
+                            if ($iter{"authorized"}) {
+                                $iter{"authorized"} = xl('yes');
                             } else {
-                                $iter["authorized"] = xl('no');
+                                $iter{"authorized"} = xl('no');
                             }
 
                             $mfa = sqlQuery(
@@ -551,11 +551,11 @@ function authorized_clicked() {
                             }
 
                             print "<tr>
-                                <td><b><a href='user_admin.php?id=" . attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) .
-                                "' class='medium_modal' onclick='top.restoreSession()'>" . text($iter["username"]) . "</a></b>" ."&nbsp;</td>
-                                <td>" . text(formatProviderNameFromRow($iter)) ."&nbsp;</td>
-                                <td>" . text($iter["info"]) . "&nbsp;</td>
-                                <td align='left'><span>" .text($iter["authorized"]) . "</td>
+                                <td><b><a href='user_admin.php?id=" . attr_url($iter{"id"}) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) .
+                                "' class='medium_modal' onclick='top.restoreSession()'>" . text($iter{"username"}) . "</a></b>" ."&nbsp;</td>
+                                <td>" . text(formatProviderNameFromRow($iter, 'admin')) ."&nbsp;</td>
+                                <td>" . text($iter{"info"}) . "&nbsp;</td>
+                                <td align='left'><span>" .text($iter{"authorized"}) . "</td>
                                 <td align='left'><span>" .text($isMfa) . "</td>";
                             print "</tr>\n";
                         }
@@ -571,9 +571,9 @@ function authorized_clicked() {
                 }
 
                 foreach ($result5 as $iter) {
-                    $grouplist[$iter["name"]] .= text($iter["user"]) .
+                    $grouplist{$iter{"name"}} .= text($iter{"user"}) .
                         "(<a class='link_submit' href='usergroup_admin.php?mode=delete_group&id=" .
-                        attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) ."' onclick='top.restoreSession()'>" . xlt('Remove') . "</a>), ";
+                        attr_url($iter{"id"}) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) ."' onclick='top.restoreSession()'>" . xlt('Remove') . "</a>), ";
                 }
 
                 foreach ($grouplist as $groupname => $list) {

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -15,6 +15,7 @@
 require_once("../globals.php");
 require_once("../../library/acl.inc");
 require_once("$srcdir/auth.inc");
+require_once("$srcdir/patient.inc");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
@@ -118,15 +119,19 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] =="user_admin") {
             sqlStatement("update users set taxonomy = ? where id= ? ", array($_POST["taxonomy"], $_POST["id"]));
         }
 
-        if ($_POST["lname"]) {
+        if (isset($_POST["lname"])) {
             sqlStatement("update users set lname=? where id= ? ", array($_POST["lname"], $_POST["id"]));
+        }
+
+        if (isset($_POST["lname2"])) {
+            sqlStatement("update users set lname2=? where id= ? ", array($_POST["lname2"], $_POST["id"]));
         }
 
         if ($_POST["job"]) {
             sqlStatement("update users set specialty=? where id= ? ", array($_POST["job"], $_POST["id"]));
         }
 
-        if ($_POST["mname"]) {
+        if (isset($_POST["mname"])) {
             sqlStatement("update users set mname=? where id= ? ", array($_POST["mname"], $_POST["id"]));
         }
 
@@ -150,7 +155,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] =="user_admin") {
             }
         }
 
-        if ($_POST["fname"]) {
+        if (isset($_POST["fname"])) {
             sqlStatement("update users set fname=? where id= ? ", array($_POST["fname"], $_POST["id"]));
         }
 
@@ -271,6 +276,7 @@ if (isset($_POST["mode"])) {
             "', fname = '"         . add_escape_custom(trim((isset($_POST['fname']) ? $_POST['fname'] : ''))) .
             "', mname = '"         . add_escape_custom(trim((isset($_POST['mname']) ? $_POST['mname'] : ''))) .
             "', lname = '"         . add_escape_custom(trim((isset($_POST['lname']) ? $_POST['lname'] : ''))) .
+            "', lname2 = '"        . add_escape_custom(trim((isset($_POST['lname2']) ? $_POST['lname2'] : ''))) .
             "', federaltaxid = '"  . add_escape_custom(trim((isset($_POST['federaltaxid']) ? $_POST['federaltaxid'] : ''))) .
             "', state_license_number = '"  . add_escape_custom(trim((isset($_POST['state_license_number']) ? $_POST['state_license_number'] : ''))) .
             "', newcrop_user_role = '"  . add_escape_custom(trim((isset($_POST['erxrole']) ? $_POST['erxrole'] : ''))) .
@@ -359,7 +365,7 @@ if (isset($_POST["mode"])) {
 
         $doit = 1;
         foreach ($result as $iter) {
-            if ($doit == 1 && $iter{"name"} == (trim((isset($_POST['groupname']) ? $_POST['groupname'] : ''))) && $iter{"user"} == (trim((isset($_POST['rumple']) ? $_POST['rumple'] : '')))) {
+            if ($doit == 1 && $iter["name"] == (trim((isset($_POST['groupname']) ? $_POST['groupname'] : ''))) && $iter["user"] == (trim((isset($_POST['rumple']) ? $_POST['rumple'] : '')))) {
                 $doit--;
             }
         }
@@ -394,7 +400,7 @@ if (isset($_GET["mode"])) {
     // reference users to make sure this user is not referenced!
 
     foreach($result as $iter) {
-      sqlStatement("delete from `groups` where user = '" . $iter{"username"} . "'");
+      sqlStatement("delete from `groups` where user = '" . $iter["username"] . "'");
     }
     sqlStatement("delete from users where id = '" . $_GET["id"] . "'");
   }
@@ -407,7 +413,7 @@ if (isset($_GET["mode"])) {
         }
 
         foreach ($result as $iter) {
-            $un = $iter{"user"};
+            $un = $iter["user"];
         }
 
         $res = sqlStatement("select name, user from `groups` where user = ? " .
@@ -527,10 +533,10 @@ function authorized_clicked() {
                         }
 
                         foreach ($result4 as $iter) {
-                            if ($iter{"authorized"}) {
-                                $iter{"authorized"} = xl('yes');
+                            if ($iter["authorized"]) {
+                                $iter["authorized"] = xl('yes');
                             } else {
-                                $iter{"authorized"} = xl('no');
+                                $iter["authorized"] = xl('no');
                             }
 
                             $mfa = sqlQuery(
@@ -545,11 +551,11 @@ function authorized_clicked() {
                             }
 
                             print "<tr>
-                                <td><b><a href='user_admin.php?id=" . attr_url($iter{"id"}) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) .
-                                "' class='medium_modal' onclick='top.restoreSession()'>" . text($iter{"username"}) . "</a></b>" ."&nbsp;</td>
-                                <td>" . text($iter{"fname"}) . ' ' . text($iter{"lname"}) ."&nbsp;</td>
-                                <td>" . text($iter{"info"}) . "&nbsp;</td>
-                                <td align='left'><span>" .text($iter{"authorized"}) . "</td>
+                                <td><b><a href='user_admin.php?id=" . attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) .
+                                "' class='medium_modal' onclick='top.restoreSession()'>" . text($iter["username"]) . "</a></b>" ."&nbsp;</td>
+                                <td>" . text(formatProviderNameFromRow($iter)) ."&nbsp;</td>
+                                <td>" . text($iter["info"]) . "&nbsp;</td>
+                                <td align='left'><span>" .text($iter["authorized"]) . "</td>
                                 <td align='left'><span>" .text($isMfa) . "</td>";
                             print "</tr>\n";
                         }
@@ -565,9 +571,9 @@ function authorized_clicked() {
                 }
 
                 foreach ($result5 as $iter) {
-                    $grouplist{$iter{"name"}} .= text($iter{"user"}) .
+                    $grouplist[$iter["name"]] .= text($iter["user"]) .
                         "(<a class='link_submit' href='usergroup_admin.php?mode=delete_group&id=" .
-                        attr_url($iter{"id"}) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) ."' onclick='top.restoreSession()'>" . xlt('Remove') . "</a>), ";
+                        attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) ."' onclick='top.restoreSession()'>" . xlt('Remove') . "</a>), ";
                 }
 
                 foreach ($grouplist as $groupname => $list) {

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -122,7 +122,7 @@ function submitform() {
             alertMsg += checkLength(f[i].name,f[i].value,35);
             alertMsg += checkUsername(f[i].name,f[i].value);
          }
-         else if(f[i].name == 'fname' || f[i].name == 'mname' || f[i].name == 'lname')
+         else if(f[i].name == 'fname' || f[i].name == 'mname' || f[i].name == 'lname' || f[i].name == 'lname2')
          {
             alertMsg += checkLength(f[i].name,f[i].value,35);
             alertMsg += checkUsername(f[i].name,f[i].value);
@@ -242,7 +242,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result2 as $iter) {
-    print "<option value='" . attr($iter{"name"}). "'>" . text($iter{"name"}) . "</option>\n";
+    print "<option value='" . attr($iter["name"]). "'>" . text($iter["name"]) . "</option>\n";
 }
 ?>
 </select></td>
@@ -258,6 +258,9 @@ foreach ($result2 as $iter) {
 </tr>
 <tr>
 <td><span class="text"><?php echo xlt('Last Name'); ?>: </span></td><td><input type=entry name='lname' id='lname' style="width:120px;" class="form-control"><span class="mandatory"></span></td>
+<td><span class="text"><?php echo xlt('Second Last Name'); ?>: </span></td><td><input type=entry name='lname2' style="width:120px;" class="form-control"></td>
+</tr>
+<tr>
 <td><span class="text"><?php echo xlt('Default Facility'); ?>: </span></td><td><select style="width:120px;" name=facility_id class="form-control">
 <?php
 $fres = $facilityService->getAllServiceLocations();
@@ -268,7 +271,7 @@ if ($fres) {
 
     foreach ($result as $iter) {
         ?>
-    <option value="<?php echo attr($iter{'id'}); ?>"><?php echo text($iter{'name'}); ?></option>
+    <option value="<?php echo attr($iter['id']); ?>"><?php echo text($iter['name']); ?></option>
         <?php
     }
 }
@@ -423,7 +426,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result as $iter) {
-    print "<option value='" . attr($iter{"username"}) . "'>" . text($iter{"username"}) . "</option>\n";
+    print "<option value='" . attr($iter["username"]) . "'>" . text($iter["username"]) . "</option>\n";
 }
 ?>
 </select>
@@ -454,7 +457,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result3 as $iter) {
-    print "<option value='" . attr($iter{"username"}) . "'>" . text($iter{"username"}) . "</option>\n";
+    print "<option value='" . attr($iter["username"]) . "'>" . text($iter["username"]) . "</option>\n";
 }
 ?>
 </select>
@@ -469,7 +472,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result2 as $iter) {
-    print "<option value='" . attr($iter{"name"}) . "'>" . text($iter{"name"}) . "</option>\n";
+    print "<option value='" . attr($iter["name"]) . "'>" . text($iter["name"]) . "</option>\n";
 }
 ?>
 </select>
@@ -489,9 +492,9 @@ if (empty($GLOBALS['disable_non_default_groups'])) {
     }
 
     foreach ($result5 as $iter) {
-        $grouplist{$iter{"name"}} .= $iter{"user"} .
+        $grouplist[$iter["name"]] .= $iter["user"] .
         "(<a class='link_submit' href='usergroup_admin.php?mode=delete_group&id=" .
-        attr_url($iter{"id"}) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) . "' onclick='top.restoreSession()'>" . xlt("Remove") . "</a>), ";
+        attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) . "' onclick='top.restoreSession()'>" . xlt("Remove") . "</a>), ";
     }
 
     foreach ($grouplist as $groupname => $list) {

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -242,7 +242,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result2 as $iter) {
-    print "<option value='" . attr($iter["name"]). "'>" . text($iter["name"]) . "</option>\n";
+    print "<option value='" . attr($iter{"name"}). "'>" . text($iter{"name"}) . "</option>\n";
 }
 ?>
 </select></td>
@@ -271,7 +271,7 @@ if ($fres) {
 
     foreach ($result as $iter) {
         ?>
-    <option value="<?php echo attr($iter['id']); ?>"><?php echo text($iter['name']); ?></option>
+    <option value="<?php echo attr($iter{'id'}); ?>"><?php echo text($iter{'name'}); ?></option>
         <?php
     }
 }
@@ -426,7 +426,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result as $iter) {
-    print "<option value='" . attr($iter["username"]) . "'>" . text($iter["username"]) . "</option>\n";
+    print "<option value='" . attr($iter{"username"}) . "'>" . text($iter{"username"}) . "</option>\n";
 }
 ?>
 </select>
@@ -457,7 +457,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result3 as $iter) {
-    print "<option value='" . attr($iter["username"]) . "'>" . text($iter["username"]) . "</option>\n";
+    print "<option value='" . attr($iter{"username"}) . "'>" . text($iter{"username"}) . "</option>\n";
 }
 ?>
 </select>
@@ -472,7 +472,7 @@ for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
 }
 
 foreach ($result2 as $iter) {
-    print "<option value='" . attr($iter["name"]) . "'>" . text($iter["name"]) . "</option>\n";
+    print "<option value='" . attr($iter{"name"}) . "'>" . text($iter{"name"}) . "</option>\n";
 }
 ?>
 </select>
@@ -492,9 +492,9 @@ if (empty($GLOBALS['disable_non_default_groups'])) {
     }
 
     foreach ($result5 as $iter) {
-        $grouplist[$iter["name"]] .= $iter["user"] .
+        $grouplist{$iter{"name"}} .= $iter{"user"} .
         "(<a class='link_submit' href='usergroup_admin.php?mode=delete_group&id=" .
-        attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) . "' onclick='top.restoreSession()'>" . xlt("Remove") . "</a>), ";
+        attr_url($iter{"id"}) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) . "' onclick='top.restoreSession()'>" . xlt("Remove") . "</a>), ";
     }
 
     foreach ($grouplist as $groupname => $list) {

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -339,7 +339,7 @@ function getProviderInfo($providerID = "%", $providers_only = true, $facility = 
         $command = "like";
     }
 
-    $query = "select distinct id, username, lname, mname, fname, authorized, info, facility, suffix, specialty, federaldrugid, federaltaxid, info " .
+    $query = "select distinct id, username, lname, lname2, mname, fname, authorized, info, facility, suffix, specialty, federaldrugid, federaltaxid, info " .
         "from users where username != '' and active = 1 and id $command '" .
         add_escape_custom($providerID) . "' " . $param1 . $param2;
     // sort by last name -- JRM June 2008
@@ -378,7 +378,7 @@ function getResponsableInfo($providerID = "%", $providers_only = true, $facility
         $command = "like";
     }
 
-    $query = "select distinct id, username, lname, mname, fname, authorized, info, facility, suffix, specialty, federaldrugid, info " .
+    $query = "select distinct id, username, lname, lname2, mname, fname, authorized, info, facility, suffix, specialty, federaldrugid, info " .
         "from users where username != '' and active = 1 and id $command '" .
         add_escape_custom($providerID) . "' " . $param1 . $param2;
     // sort by last name -- JRM June 2008
@@ -414,7 +414,7 @@ function getCalendarProviderInfo($providerID = "%", $providers_only = true)
         $command = "like";
     }
 
-    $query = "select distinct id, username, lname, fname, authorized, info, facility, suffix, specialty, federaldrugid, info " .
+    $query = "select distinct id, username, lname, lname2, fname, authorized, info, facility, suffix, specialty, federaldrugid, info " .
         "from users where username != '' and active = 1 and id $command '" .
         add_escape_custom($providerID) . "' " . $param1;
 
@@ -428,36 +428,78 @@ function getCalendarProviderInfo($providerID = "%", $providers_only = true)
 
 function getProviderName($providerID, $provider_only = 'any')
 {
-    $pi = getProviderInfo($providerID, 'any');
-    if (strlen($pi[0]["fname"]) > 0) {
-        if (strlen($pi[0]["lname"]) > 0) {
-            $pi[0]["tname"] .= $pi[0]["suffix"] . " " . $pi[0]["fname"];
-        }
-
-        return $pi[0]['tname'] . " " . $pi[0]['lname'];
-    }
-
-    return "";
+    return getProviderFullName($providerID, 'clinical');
 }
 
 function getProviderNameConcat($providerID, $provider_only = 'any')
 {
-    $pi = getProviderInfo($providerID, 'any');
+    return getProviderFullName($providerID, 'clinical');
+}
 
-    $fullName = '';
-    if (isset($pi[0]["fname"]) && strlen($pi[0]["fname"]) > 0) {
-        $fullName .= $pi[0]["fname"] . " ";
+function getProviderFullName($providerID, $format = 'clinical')
+{
+    $parts = getProviderNameParts($providerID);
+    if (empty($parts)) {
+        return "";
     }
 
-    if (isset($pi[0]["mname"]) && strlen($pi[0]["mname"]) > 0) {
-        $fullName .= $pi[0]["mname"] . " ";
+    return formatProviderNameParts($parts, $format);
+}
+
+function formatProviderNameFromRow($row, $format = 'clinical')
+{
+    if (empty($row) || !is_array($row)) {
+        return "";
     }
 
-    if (isset($pi[0]["lname"]) && strlen($pi[0]["lname"]) > 0) {
-        $fullName .= $pi[0]["lname"] . " ";
+    return formatProviderNameParts([
+        'fname' => $row['fname'] ?? '',
+        'mname' => $row['mname'] ?? '',
+        'lname' => $row['lname'] ?? '',
+        'lname2' => $row['lname2'] ?? '',
+        'suffix' => $row['suffix'] ?? '',
+        'apellido_1' => $row['lname'] ?? '',
+        'apellido_2' => $row['lname2'] ?? ''
+    ], $format);
+}
+
+function formatProviderNameParts($parts, $format = 'clinical')
+{
+    $firstNames = providerNameJoinParts([
+        $parts['suffix'] ?? '',
+        $parts['fname'] ?? '',
+        $parts['mname'] ?? ''
+    ]);
+    $lastNames = providerNameJoinParts([
+        $parts['apellido_1'] ?? $parts['lname'] ?? '',
+        $parts['apellido_2'] ?? $parts['lname2'] ?? ''
+    ]);
+
+    if ($format === 'list') {
+        return trim($lastNames . (($lastNames !== '' && $firstNames !== '') ? ', ' : '') . $firstNames);
     }
 
-    return trim($fullName);
+    if ($format === 'short') {
+        return providerNameJoinParts([
+            $parts['fname'] ?? '',
+            $parts['apellido_1'] ?? $parts['lname'] ?? ''
+        ]);
+    }
+
+    return providerNameJoinParts([$firstNames, $lastNames]);
+}
+
+function providerNameJoinParts($parts)
+{
+    $normalizedParts = [];
+    foreach ($parts as $part) {
+        $part = trim((string) $part);
+        if ($part !== '') {
+            $normalizedParts[] = $part;
+        }
+    }
+
+    return implode(' ', $normalizedParts);
 }
 
 function getProviderNameParts($providerID)
@@ -471,47 +513,27 @@ function getProviderNameParts($providerID)
     $fname = trim($pi[0]['fname'] ?? '');
     $mname = trim($pi[0]['mname'] ?? '');
     $lname = trim($pi[0]['lname'] ?? '');
-
-    $tokens = preg_split('/\s+/', $lname);
-
-    $prefijos = ['de', 'del', 'la', 'los', 'las'];
-    $apellidos = [];
-
-    $i = 0;
-    while ($i < count($tokens)) {
-        $token = strtolower($tokens[$i]);
-
-        // Prefijos tipo: de, del, de la, de los, etc.
-        if ($token === 'de') {
-            $compuesto = $tokens[$i];
-
-            // de + la / los / las
-            if (isset($tokens[$i + 1]) && in_array(strtolower($tokens[$i + 1]), ['la', 'los', 'las'])) {
-                $compuesto .= ' ' . $tokens[$i + 1];
-                $i++;
-            }
-
-            // agregar la siguiente palabra (apellido real)
-            if (isset($tokens[$i + 1])) {
-                $compuesto .= ' ' . $tokens[$i + 1];
-                $i++;
-            }
-
-            $apellidos[] = $compuesto;
-        } else {
-            $apellidos[] = $tokens[$i];
-        }
-
-        $i++;
-    }
+    $lname2 = trim($pi[0]['lname2'] ?? '');
+    $suffix = trim($pi[0]['suffix'] ?? '');
 
     return [
         'fname'       => $fname,
         'mname'       => $mname,
-        'apellido_1'  => $apellidos[0] ?? '',
-        'apellido_2'  => $apellidos[1] ?? '',
-        'apellidos'   => implode(' ', $apellidos),
-        'full_name'   => trim("$fname $mname " . implode(' ', $apellidos))
+        'lname'       => $lname,
+        'lname2'      => $lname2,
+        'suffix'      => $suffix,
+        'apellido_1'  => $lname,
+        'apellido_2'  => $lname2,
+        'apellidos'   => providerNameJoinParts([$lname, $lname2]),
+        'full_name'   => formatProviderNameParts([
+            'fname' => $fname,
+            'mname' => $mname,
+            'lname' => $lname,
+            'lname2' => $lname2,
+            'suffix' => $suffix,
+            'apellido_1' => $lname,
+            'apellido_2' => $lname2
+        ])
     ];
 }
 
@@ -739,11 +761,11 @@ function getPatientLnames($term = "%", $given = "pid, id, lname, fname, mname, p
     }
 
     if (!empty($GLOBALS['pt_restrict_field'])) {
-        if ($_SESSION{"authUser"} != 'admin' || $GLOBALS['pt_restrict_admin']) {
+        if ($_SESSION["authUser"] != 'admin' || $GLOBALS['pt_restrict_admin']) {
             $where .= " AND ( patient_data." . add_escape_custom($GLOBALS['pt_restrict_field']) .
                 " = ( SELECT facility_id FROM users WHERE username = ?) OR patient_data." .
                 add_escape_custom($GLOBALS['pt_restrict_field']) . " = '' ) ";
-            array_push($sqlBindArray, $_SESSION{"authUser"});
+            array_push($sqlBindArray, $_SESSION["authUser"]);
         }
     }
 
@@ -818,11 +840,11 @@ function getPatientId($pid = "%", $given = "pid, id, lname, fname, mname, provid
     $where = "pubpid LIKE ? ";
     array_push($sqlBindArray, $pid . "%");
     if (!empty($GLOBALS['pt_restrict_field']) && $GLOBALS['pt_restrict_by_id']) {
-        if ($_SESSION{"authUser"} != 'admin' || $GLOBALS['pt_restrict_admin']) {
+        if ($_SESSION["authUser"] != 'admin' || $GLOBALS['pt_restrict_admin']) {
             $where .= "AND ( patient_data." . add_escape_custom($GLOBALS['pt_restrict_field']) .
                 " = ( SELECT facility_id FROM users WHERE username = ?) OR patient_data." .
                 add_escape_custom($GLOBALS['pt_restrict_field']) . " = '' ) ";
-            array_push($sqlBindArray, $_SESSION{"authUser"});
+            array_push($sqlBindArray, $_SESSION["authUser"]);
         }
     }
 
@@ -1035,11 +1057,11 @@ function getPatientDOB($DOB = "%", $given = "pid, id, lname, fname, mname", $ord
     $where = "DOB like ? ";
     array_push($sqlBindArray, $DOB . "%");
     if (!empty($GLOBALS['pt_restrict_field'])) {
-        if ($_SESSION{"authUser"} != 'admin' || $GLOBALS['pt_restrict_admin']) {
+        if ($_SESSION["authUser"] != 'admin' || $GLOBALS['pt_restrict_admin']) {
             $where .= "AND ( patient_data." . add_escape_custom($GLOBALS['pt_restrict_field']) .
                 " = ( SELECT facility_id FROM users WHERE username = ?) OR patient_data." .
                 add_escape_custom($GLOBALS['pt_restrict_field']) . " = '' ) ";
-            array_push($sqlBindArray, $_SESSION{"authUser"});
+            array_push($sqlBindArray, $_SESSION["authUser"]);
         }
     }
 

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -428,12 +428,22 @@ function getCalendarProviderInfo($providerID = "%", $providers_only = true)
 
 function getProviderName($providerID, $provider_only = 'any')
 {
-    return getProviderFullName($providerID, 'clinical');
+    $pi = getProviderInfo($providerID, 'any');
+    if (empty($pi[0])) {
+        return "";
+    }
+
+    return formatProviderNameFromRow($pi[0], 'legacy_name');
 }
 
 function getProviderNameConcat($providerID, $provider_only = 'any')
 {
-    return getProviderFullName($providerID, 'clinical');
+    $pi = getProviderInfo($providerID, 'any');
+    if (empty($pi[0])) {
+        return "";
+    }
+
+    return formatProviderNameFromRow($pi[0], 'legacy_concat');
 }
 
 function getProviderFullName($providerID, $format = 'clinical')
@@ -452,21 +462,12 @@ function formatProviderNameFromRow($row, $format = 'clinical')
         return "";
     }
 
-    return formatProviderNameParts([
-        'fname' => $row['fname'] ?? '',
-        'mname' => $row['mname'] ?? '',
-        'lname' => $row['lname'] ?? '',
-        'lname2' => $row['lname2'] ?? '',
-        'suffix' => $row['suffix'] ?? '',
-        'apellido_1' => $row['lname'] ?? '',
-        'apellido_2' => $row['lname2'] ?? ''
-    ], $format);
+    return formatProviderNameParts(providerNamePartsFromRow($row), $format);
 }
 
 function formatProviderNameParts($parts, $format = 'clinical')
 {
     $firstNames = providerNameJoinParts([
-        $parts['suffix'] ?? '',
         $parts['fname'] ?? '',
         $parts['mname'] ?? ''
     ]);
@@ -486,7 +487,48 @@ function formatProviderNameParts($parts, $format = 'clinical')
         ]);
     }
 
+    if ($format === 'legacy_name') {
+        return providerNameFormatLegacyName($parts);
+    }
+
+    if ($format === 'legacy_concat') {
+        return providerNameJoinParts([
+            $parts['fname'] ?? '',
+            $parts['mname'] ?? '',
+            $lastNames
+        ]);
+    }
+
+    if ($format === 'admin') {
+        return providerNameJoinParts([
+            $parts['fname'] ?? '',
+            $lastNames
+        ]);
+    }
+
     return providerNameJoinParts([$firstNames, $lastNames]);
+}
+
+function providerNameFormatLegacyName($parts)
+{
+    $fname = trim((string)($parts['fname'] ?? ''));
+    if ($fname === '') {
+        return "";
+    }
+
+    $lastNames = providerNameJoinParts([
+        $parts['apellido_1'] ?? $parts['lname'] ?? '',
+        $parts['apellido_2'] ?? $parts['lname2'] ?? ''
+    ]);
+    $nameParts = [];
+    if ($lastNames !== '') {
+        $nameParts[] = $parts['suffix'] ?? '';
+    }
+
+    $nameParts[] = $fname;
+    $nameParts[] = $lastNames;
+
+    return providerNameJoinParts($nameParts);
 }
 
 function providerNameJoinParts($parts)
@@ -510,11 +552,17 @@ function getProviderNameParts($providerID)
         return null;
     }
 
-    $fname = trim($pi[0]['fname'] ?? '');
-    $mname = trim($pi[0]['mname'] ?? '');
-    $lname = trim($pi[0]['lname'] ?? '');
-    $lname2 = trim($pi[0]['lname2'] ?? '');
-    $suffix = trim($pi[0]['suffix'] ?? '');
+    return providerNamePartsFromRow($pi[0]);
+}
+
+function providerNamePartsFromRow($row)
+{
+    $fname = trim($row['fname'] ?? '');
+    $mname = trim($row['mname'] ?? '');
+    $lname = trim($row['lname'] ?? '');
+    $lname2 = trim($row['lname2'] ?? '');
+    $suffix = trim($row['suffix'] ?? '');
+    $apellidos = providerNameLastNameParts($lname, $lname2);
 
     return [
         'fname'       => $fname,
@@ -522,19 +570,58 @@ function getProviderNameParts($providerID)
         'lname'       => $lname,
         'lname2'      => $lname2,
         'suffix'      => $suffix,
-        'apellido_1'  => $lname,
-        'apellido_2'  => $lname2,
-        'apellidos'   => providerNameJoinParts([$lname, $lname2]),
+        'apellido_1'  => $apellidos[0] ?? '',
+        'apellido_2'  => $apellidos[1] ?? '',
+        'apellidos'   => providerNameJoinParts($apellidos),
         'full_name'   => formatProviderNameParts([
             'fname' => $fname,
             'mname' => $mname,
             'lname' => $lname,
             'lname2' => $lname2,
             'suffix' => $suffix,
-            'apellido_1' => $lname,
-            'apellido_2' => $lname2
+            'apellido_1' => $apellidos[0] ?? '',
+            'apellido_2' => $apellidos[1] ?? ''
         ])
     ];
+}
+
+function providerNameLastNameParts($lname, $lname2 = '')
+{
+    $lname = trim((string)$lname);
+    $lname2 = trim((string)$lname2);
+    if ($lname2 !== '') {
+        return [$lname, $lname2];
+    }
+
+    $tokens = preg_split('/\s+/', $lname, -1, PREG_SPLIT_NO_EMPTY);
+    $apellidos = [];
+
+    $i = 0;
+    while ($i < count($tokens)) {
+        $token = strtolower($tokens[$i]);
+
+        if ($token === 'de') {
+            $compuesto = $tokens[$i];
+
+            if (isset($tokens[$i + 1]) && in_array(strtolower($tokens[$i + 1]), ['la', 'los', 'las'])) {
+                $compuesto .= ' ' . $tokens[$i + 1];
+                $i++;
+            }
+
+            if (isset($tokens[$i + 1])) {
+                $compuesto .= ' ' . $tokens[$i + 1];
+                $i++;
+            }
+
+            $apellidos[] = $compuesto;
+        } else {
+            $apellidos[] = $tokens[$i];
+        }
+
+        $i++;
+    }
+
+    return $apellidos;
 }
 
 function getResponsableName($providerID)
@@ -761,11 +848,11 @@ function getPatientLnames($term = "%", $given = "pid, id, lname, fname, mname, p
     }
 
     if (!empty($GLOBALS['pt_restrict_field'])) {
-        if ($_SESSION["authUser"] != 'admin' || $GLOBALS['pt_restrict_admin']) {
+        if ($_SESSION{"authUser"} != 'admin' || $GLOBALS['pt_restrict_admin']) {
             $where .= " AND ( patient_data." . add_escape_custom($GLOBALS['pt_restrict_field']) .
                 " = ( SELECT facility_id FROM users WHERE username = ?) OR patient_data." .
                 add_escape_custom($GLOBALS['pt_restrict_field']) . " = '' ) ";
-            array_push($sqlBindArray, $_SESSION["authUser"]);
+            array_push($sqlBindArray, $_SESSION{"authUser"});
         }
     }
 
@@ -840,11 +927,11 @@ function getPatientId($pid = "%", $given = "pid, id, lname, fname, mname, provid
     $where = "pubpid LIKE ? ";
     array_push($sqlBindArray, $pid . "%");
     if (!empty($GLOBALS['pt_restrict_field']) && $GLOBALS['pt_restrict_by_id']) {
-        if ($_SESSION["authUser"] != 'admin' || $GLOBALS['pt_restrict_admin']) {
+        if ($_SESSION{"authUser"} != 'admin' || $GLOBALS['pt_restrict_admin']) {
             $where .= "AND ( patient_data." . add_escape_custom($GLOBALS['pt_restrict_field']) .
                 " = ( SELECT facility_id FROM users WHERE username = ?) OR patient_data." .
                 add_escape_custom($GLOBALS['pt_restrict_field']) . " = '' ) ";
-            array_push($sqlBindArray, $_SESSION["authUser"]);
+            array_push($sqlBindArray, $_SESSION{"authUser"});
         }
     }
 
@@ -1057,11 +1144,11 @@ function getPatientDOB($DOB = "%", $given = "pid, id, lname, fname, mname", $ord
     $where = "DOB like ? ";
     array_push($sqlBindArray, $DOB . "%");
     if (!empty($GLOBALS['pt_restrict_field'])) {
-        if ($_SESSION["authUser"] != 'admin' || $GLOBALS['pt_restrict_admin']) {
+        if ($_SESSION{"authUser"} != 'admin' || $GLOBALS['pt_restrict_admin']) {
             $where .= "AND ( patient_data." . add_escape_custom($GLOBALS['pt_restrict_field']) .
                 " = ( SELECT facility_id FROM users WHERE username = ?) OR patient_data." .
                 add_escape_custom($GLOBALS['pt_restrict_field']) . " = '' ) ";
-            array_push($sqlBindArray, $_SESSION["authUser"]);
+            array_push($sqlBindArray, $_SESSION{"authUser"});
         }
     }
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -6638,6 +6638,7 @@ CREATE TABLE `users` (
   `fname` varchar(255) default NULL,
   `mname` varchar(255) default NULL,
   `lname` varchar(255) default NULL,
+  `lname2` varchar(255) default NULL,
   `suffix` varchar(255) default NULL,
   `federaltaxid` varchar(255) default NULL,
   `federaldrugid` varchar(255) default NULL,

--- a/sql/patch.sql
+++ b/sql/patch.sql
@@ -264,3 +264,7 @@ ALTER TABLE `form_eye_neuro` MODIFY `ODCOINS` text;
 #IfNotColumnType form_eye_neuro OSCOINS text
 ALTER TABLE `form_eye_neuro` MODIFY `OSCOINS` text;
 #EndIf
+
+#IfMissingColumn users lname2
+ALTER TABLE `users` ADD COLUMN `lname2` varchar(255) default NULL AFTER `lname`;
+#EndIf

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -307,6 +307,11 @@ class User
     private $lname;
 
     /**
+     * @Column(name="lname2", type="string")
+     */
+    private $lname2;
+
+    /**
      * @Column(name="mname", type="string")
      */
     private $mname;
@@ -424,6 +429,16 @@ class User
     public function setLname($value)
     {
         $this->lname = $value;
+    }
+
+    public function getLname2()
+    {
+        return $this->lname2;
+    }
+
+    public function setLname2($value)
+    {
+        $this->lname2 = $value;
     }
 
     public function getSuffix()
@@ -942,6 +957,7 @@ class User
                "fname: '" . $this->getFname() . "' " .
                "mname: '" . $this->getMname() . "' " .
                "lname: '" . $this->getLname() . "' " .
+               "lname2: '" . $this->getLname2() . "' " .
                "suffix: '" . $this->getSuffix() . "' " .
                "federalTaxId: '" . $this->getFederalTaxId() . "' " .
                "federalDrugId: '" . $this->getFederalDrugId() . "' " .

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -60,7 +60,7 @@ class UserRepository extends EntityRepository
         $criteria = Criteria::create();
         $criteria->where(Criteria::expr()->neq("username", ""));
         $criteria->andWhere(Criteria::expr()->eq("active", 1));
-        $criteria->orderBy(array("lname" => "ASC", "fname" => "ASC", "mname" => "ASC"));
+        $criteria->orderBy(array("lname" => "ASC", "lname2" => "ASC", "fname" => "ASC", "mname" => "ASC"));
         $results = $this->_em->getRepository($this->_entityName)->matching($criteria);
         return $results;
     }

--- a/src/Services/ProviderService.php
+++ b/src/Services/ProviderService.php
@@ -27,6 +27,7 @@ class ProviderService
         $sql = "SELECT id,
                        fname,
                        lname,
+                       lname2,
                        mname,
                        username
                 FROM  users
@@ -47,6 +48,7 @@ class ProviderService
         $sql = "SELECT id,
                        fname,
                        lname,
+                       lname2,
                        mname,
                        username
                 FROM  users

--- a/tests/provider_name_format_regression.php
+++ b/tests/provider_name_format_regression.php
@@ -1,0 +1,154 @@
+<?php
+
+    $failures = [];
+    $patientInc = file_get_contents(__DIR__ . '/../library/patient.inc');
+    $functionsToLoad = [
+        'formatProviderNameFromRow',
+        'formatProviderNameParts',
+        'providerNameFormatLegacyName',
+        'providerNameJoinParts',
+        'providerNamePartsFromRow',
+        'providerNameLastNameParts',
+    ];
+
+    foreach ($functionsToLoad as $functionName) {
+        eval(extractFunctionSource($patientInc, $functionName));
+    }
+
+    function extractFunctionSource($source, $functionName)
+    {
+        $pattern = '/function\s+' . preg_quote($functionName, '/') . '\s*\(/';
+        if (!preg_match($pattern, $source, $match, PREG_OFFSET_CAPTURE)) {
+            throw new RuntimeException('Function not found: ' . $functionName);
+        }
+
+        $start = $match[0][1];
+        $braceStart = strpos($source, '{', $start);
+        if ($braceStart === false) {
+            throw new RuntimeException('Function body not found: ' . $functionName);
+        }
+
+        $depth = 0;
+        $length = strlen($source);
+        for ($i = $braceStart; $i < $length; $i++) {
+            if ($source[$i] === '{') {
+                $depth++;
+            } elseif ($source[$i] === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return substr($source, $start, $i - $start + 1);
+                }
+            }
+        }
+
+        throw new RuntimeException('Function body is incomplete: ' . $functionName);
+    }
+
+    function assertSameValue($label, $expected, $actual)
+    {
+        global $failures;
+        if ($expected !== $actual) {
+            $failures[] = $label . ': expected [' . $expected . '] got [' . $actual . ']';
+        }
+    }
+
+    function assertNoDoubleSpaces($label, $actual)
+    {
+        global $failures;
+        if (strpos($actual, '  ') !== false) {
+            $failures[] = $label . ': contains double spaces [' . $actual . ']';
+        }
+    }
+
+    function providerParts($row)
+    {
+        return providerNamePartsFromRow($row);
+    }
+
+    $cases = [
+        'fname + lname' => [
+            ['fname' => 'John', 'mname' => '', 'lname' => 'Doe'],
+            'clinical' => 'John Doe',
+            'legacy_name' => 'John Doe',
+            'legacy_concat' => 'John Doe',
+            'apellido_1' => 'Doe',
+            'apellido_2' => ''
+        ],
+        'fname + lname + lname2' => [
+            ['fname' => 'John', 'mname' => '', 'lname' => 'Doe', 'lname2' => 'Smith'],
+            'clinical' => 'John Doe Smith',
+            'legacy_name' => 'John Doe Smith',
+            'legacy_concat' => 'John Doe Smith',
+            'apellido_1' => 'Doe',
+            'apellido_2' => 'Smith'
+        ],
+        'fname + mname + lname + lname2' => [
+            ['fname' => 'John', 'mname' => 'Paul', 'lname' => 'Doe', 'lname2' => 'Smith'],
+            'clinical' => 'John Paul Doe Smith',
+            'legacy_name' => 'John Doe Smith',
+            'legacy_concat' => 'John Paul Doe Smith',
+            'apellido_1' => 'Doe',
+            'apellido_2' => 'Smith'
+        ],
+        'lname2 NULL' => [
+            ['fname' => 'John', 'mname' => '', 'lname' => 'Doe', 'lname2' => null],
+            'clinical' => 'John Doe',
+            'legacy_name' => 'John Doe',
+            'legacy_concat' => 'John Doe',
+            'apellido_1' => 'Doe',
+            'apellido_2' => ''
+        ],
+        'lname2 empty' => [
+            ['fname' => 'John', 'mname' => '', 'lname' => 'Doe', 'lname2' => ''],
+            'clinical' => 'John Doe',
+            'legacy_name' => 'John Doe',
+            'legacy_concat' => 'John Doe',
+            'apellido_1' => 'Doe',
+            'apellido_2' => ''
+        ],
+        'additional spaces' => [
+            ['fname' => ' John ', 'mname' => ' Paul ', 'lname' => ' Doe ', 'lname2' => ' Smith '],
+            'clinical' => 'John Paul Doe Smith',
+            'legacy_name' => 'John Doe Smith',
+            'legacy_concat' => 'John Paul Doe Smith',
+            'apellido_1' => 'Doe',
+            'apellido_2' => 'Smith'
+        ],
+        'historical compound lname' => [
+            ['fname' => 'Juan', 'mname' => '', 'lname' => 'de la Cruz Perez', 'lname2' => ''],
+            'clinical' => 'Juan de la Cruz Perez',
+            'legacy_name' => 'Juan de la Cruz Perez',
+            'legacy_concat' => 'Juan de la Cruz Perez',
+            'apellido_1' => 'de la Cruz',
+            'apellido_2' => 'Perez'
+        ],
+        'legacy suffix handling' => [
+            ['fname' => 'John', 'mname' => 'Paul', 'lname' => 'Doe', 'lname2' => 'Smith', 'suffix' => 'Dr.'],
+            'clinical' => 'John Paul Doe Smith',
+            'legacy_name' => 'Dr. John Doe Smith',
+            'legacy_concat' => 'John Paul Doe Smith',
+            'apellido_1' => 'Doe',
+            'apellido_2' => 'Smith'
+        ],
+    ];
+
+    foreach ($cases as $label => $case) {
+        $parts = providerParts($case[0]);
+
+        assertSameValue($label . ' apellido_1', $case['apellido_1'], $parts['apellido_1']);
+        assertSameValue($label . ' apellido_2', $case['apellido_2'], $parts['apellido_2']);
+        assertSameValue($label . ' clinical', $case['clinical'], formatProviderNameParts($parts));
+        assertSameValue($label . ' legacy_name', $case['legacy_name'], formatProviderNameFromRow($case[0], 'legacy_name'));
+        assertSameValue($label . ' legacy_concat', $case['legacy_concat'], formatProviderNameFromRow($case[0], 'legacy_concat'));
+
+        assertNoDoubleSpaces($label . ' clinical', formatProviderNameParts($parts));
+        assertNoDoubleSpaces($label . ' legacy_name', formatProviderNameFromRow($case[0], 'legacy_name'));
+        assertNoDoubleSpaces($label . ' legacy_concat', formatProviderNameFromRow($case[0], 'legacy_concat'));
+    }
+
+    if ($failures) {
+        fwrite(STDERR, implode(PHP_EOL, $failures) . PHP_EOL);
+        exit(1);
+    }
+
+    echo "Provider name format regression tests passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- Adds users.lname2 through database.sql and the guarded OpenEMR patch mechanism.
- Exposes lname2 in the User entity, provider repository/service queries, and administrative user/address book forms.
- Centralizes provider name formatting in library/patient.inc while preserving legacy output when lname2 is NULL or empty.
- Adds a standalone provider name formatting regression test without new dependencies.

## Scope
This PR intentionally recovers only the provider second-last-name and centralized provider-name formatting portion of contaminated commit e1d868e7802149afba233f41a1d76ffe969b075b.

Out of scope: clinical forms, PDFs, EyeMag, CIE10, consents, IESS reports, KPI, faco.json, temporary files, Patient V1 documentation, TCPDF font deletion, and unrelated PHP 8 syntax cleanup.

## Legacy compatibility
- When users.lname2 is NULL or empty, getProviderNameParts() keeps the legacy parser for historical compound last names stored in users.lname.
- When users.lname2 has a value, lname is treated as first last name and lname2 as second last name.
- getProviderName() preserves the old fname/lname-oriented output and suffix behavior; it only appends lname2 when present.
- getProviderNameConcat() preserves the old fname/mname/lname output; it only appends lname2 when present.
- Formatting helpers trim components and avoid double spaces.

## Validation
- php tests/provider_name_format_regression.php: passed.
- git diff --check origin/master..HEAD: passed.
- SQL guard check: one database.sql lname2 definition, one patch.sql #IfMissingColumn guard, one ADD COLUMN statement.
- Confirmed PR diff contains only the approved functional files plus tests/provider_name_format_regression.php added for this correction.

## PHP 8 preexisting debt
Kept unrelated curly-offset syntax unchanged per review scope. php -l still fails on legacy syntax in:
- interface/usergroup/usergroup_admin.php: Array/string offset access with curly braces.
- interface/usergroup/usergroup_admin_add.php: Array/string offset access with curly braces.
- library/patient.inc: Array/string offset access with curly braces.

Refs #58